### PR TITLE
With Statement Control Flow Template: 3.10 #32

### DIFF
--- a/pylingual/control_flow_reconstruction/templates/With.py
+++ b/pylingual/control_flow_reconstruction/templates/With.py
@@ -52,7 +52,7 @@ class WithCleanup3_9(ControlFlowTemplate):
 
     try_match = make_try_match({EdgeKind.Fall: "tail"}, "start", "reraise", "poptop")
 
-    @override
+    @to_indented_source
     def to_indented_source(self, source):
         """
         {poptop}

--- a/pylingual/control_flow_reconstruction/templates/With.py
+++ b/pylingual/control_flow_reconstruction/templates/With.py
@@ -40,10 +40,10 @@ class With3_12(ControlFlowTemplate):
             {with_body}
         """
 
-class WithCleanup3_10(ControlFlowTemplate):
+class WithCleanup3_9(ControlFlowTemplate):
     template = T(
         start=~N("reraise", "poptop").with_cond(
-            starting_instructions("WITH_EXCEPT_START"),  # 3.10
+            starting_instructions("WITH_EXCEPT_START"),  # 3.9 & 3.10
         ),
         reraise=+N().with_cond(exact_instructions("RERAISE")).with_in_deg(1),
         poptop=~N("tail.", None).with_cond(starting_instructions("POP_TOP")).with_in_deg(1),
@@ -58,12 +58,12 @@ class WithCleanup3_10(ControlFlowTemplate):
         {poptop}
         """
 
-@register_template(0, 10, *versions_from(3, 10))
-class With3_10(ControlFlowTemplate):
+@register_template(0, 10, (3, 9), (3, 10))
+class With3_9(ControlFlowTemplate):
     template = T(
         setup_with=~N("with_body", None),
         with_body=N("normal_cleanup.", None, "exc_cleanup").with_in_deg(1),
-        exc_cleanup=N.tail().of_subtemplate(WithCleanup3_10).with_in_deg(1),
+        exc_cleanup=N.tail().of_subtemplate(WithCleanup3_9).with_in_deg(1),
         normal_cleanup=~N.tail(),
     )
 
@@ -75,4 +75,22 @@ class With3_10(ControlFlowTemplate):
         {setup_with}
             {with_body}
         {exc_cleanup}
+        """
+
+@register_template(0, 10, (3, 8))
+class With3_8(ControlFlowTemplate):
+    template = T(
+        setup_with=~N("with_body", None),
+        with_body=N("begin_finally.", None, "normal_cleanup").with_in_deg(1),
+        begin_finally=~N("normal_cleanup.", None).with_in_deg(1),
+        normal_cleanup=~N.tail(),
+    )
+
+    try_match = make_try_match({EdgeKind.Fall: "normal_cleanup"}, "setup_with", "with_body", "begin_finally")
+
+    @to_indented_source
+    def to_indented_source():
+        """
+        {setup_with}
+            {with_body}
         """


### PR DESCRIPTION

### With Statement Control Flow Template: 3.10
- [x] a() With
- [x] b() Multiple withs
```python 
with a, b:
    print(1)
```
> Simpler b() fails due to python bytecode redundancies (?) which results in a dangling node 

- [x] c() With-as
- [x] d() Multiple with-as
```python
with a as c, b as d:
    print(1)
```
> Simpler d() fails due to same reason as b()
- [x] e() Async-with
- [x] f() Multiple async-withs
- [x] g() Async-with-as
- [x] h() Multiple async-with-as

### Additional Cases
- [ ] i() With statements with outer exception handlers
- [x] j() With statements with premature returns (return)
- [x] k() With statements with premature returns (raise)
