### PR TITLE
Some try-except 3.10 fixes and the most basic case of try-finally

### DIFF
--- a/dev_scripts/cflow.py
+++ b/dev_scripts/cflow.py
@@ -97,16 +97,16 @@ def print_results(a: Path, b: Path, result: Result, results: list[tuple[bool, st
     a_text = a.read_text()
     b_text = b.read_text()
     console = rich.console.Console(highlight=False)
-    console.print("=== original file ===", style='green bold')
+    console.print("=== original file ===", style="green bold")
     console.print(a_text)
-    console.print("\n=== reconstructed file ===", style='green bold')
+    console.print("\n=== reconstructed file ===", style="green bold")
     console.print(b_text)
-    console.print("\n=== equivalence report ===", style='green bold')
+    console.print("\n=== equivalence report ===", style="green bold")
     if results:
         for success, name in results:
-            console.print(name, style='' if success else 'red bold underline')
+            console.print(name, style="" if success else "red bold underline")
     else:
-        console.print(result, style='red bold underline')
+        console.print(result, style="red bold underline")
 
 
 def get_unused(a: Path, _=True):

--- a/pylingual/control_flow_reconstruction/cft.py
+++ b/pylingual/control_flow_reconstruction/cft.py
@@ -326,6 +326,8 @@ class ControlFlowTemplate(ABC):
         self._pos = sum((x._pos for x in members.values() if x is not None), start=[])
 
     def pos(self):
+        if not self._pos:
+            return "0.0,0.0!"
         avg_x = sum(x for x, _ in self._pos) / len(self._pos)
         avg_y = sum(y for _, y in self._pos) / len(self._pos)
         return f"{avg_x},{avg_y}!"

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -263,7 +263,7 @@ class TryFinally3_10(ControlFlowTemplate):
         tail=N.tail(),
     )
     template2 = T(
-        try_except=N("finally_tail", None, "fail_body").of_subtemplate(Try3_10),
+        try_except=N("finally_tail", None, "fail_body").of_type(TryElse3_10, Try3_10),
         finally_tail=N("finally_body", None, "fail_body"),
         finally_body=~N("tail.").with_in_deg(1).with_cond(no_back_edges),
         fail_body=N("tail.").with_cond(with_instructions("RERAISE")),

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -118,7 +118,6 @@ class TryElse3_12(ControlFlowTemplate):
 @register_template(0, 1, (3, 10))
 class Try3_10(ControlFlowTemplate):
     template = T(
-        try_header=~N("try_body"),
         try_body=N("try_footer.", None, "except_body"),
         try_footer=~N("tail."),
         except_body=~N("tail.").of_subtemplate(Except3_10),
@@ -130,7 +129,6 @@ class Try3_10(ControlFlowTemplate):
             {
                 EdgeKind.Fall: "tail",
             },
-            "try_header",
             "try_body",
             "except_body",
             "try_footer",
@@ -140,7 +138,6 @@ class Try3_10(ControlFlowTemplate):
     @to_indented_source
     def to_indented_source():
         """
-        {try_header}
         try:
             {try_body}
         {except_body}
@@ -149,7 +146,6 @@ class Try3_10(ControlFlowTemplate):
 @register_template(0, 0, (3, 10))
 class TryElse3_10(ControlFlowTemplate):
     template = T(
-        try_header=N("try_body"),
         try_body=N("try_footer.", None, "except_body"),
         try_footer=N("else_body").with_in_deg(1),
         except_body=N("tail.").with_in_deg(1).of_subtemplate(Except3_10),
@@ -162,7 +158,6 @@ class TryElse3_10(ControlFlowTemplate):
             {
                 EdgeKind.Fall: "tail",
             },
-            "try_header",
             "try_body",
             "try_footer",
             "except_body",
@@ -173,7 +168,6 @@ class TryElse3_10(ControlFlowTemplate):
     @to_indented_source
     def to_indented_source():
         """
-        {try_header}
         try:
             {try_body}
         {except_body}
@@ -206,7 +200,7 @@ class NamedExc3_10(ExcBody3_10):
 
 class BareExcept3_10(Except3_10):
     template = T(
-        except_body=~N("tail.", None).of_type(BlockTemplate).with_cond(with_instructions("POP_EXCEPT")),
+        except_body=~N("tail.", None).of_type(BlockTemplate).with_cond(with_instructions("POP_EXCEPT"), with_instructions("RAISE_VARARGS")),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -35,6 +35,7 @@ class Except3_11(ControlFlowTemplate):
         if x := BareExcept3_11.try_match(cfg, node):
             return x
 
+
 class Except3_10(ControlFlowTemplate):
     @classmethod
     @override
@@ -47,6 +48,7 @@ class Except3_10(ControlFlowTemplate):
             return x
         if isinstance(node, Except3_10):
             return node
+
 
 @register_template(0, 0, *versions_from(3, 12))
 class Try3_12(ControlFlowTemplate):
@@ -115,6 +117,7 @@ class TryElse3_12(ControlFlowTemplate):
             {try_else}
         """
 
+
 @register_template(0, 1, (3, 10))
 class Try3_10(ControlFlowTemplate):
     template = T(
@@ -145,6 +148,7 @@ class Try3_10(ControlFlowTemplate):
             {try_body}
         {except_body}
         """
+
 
 @register_template(0, 0, (3, 10))
 class TryElse3_10(ControlFlowTemplate):
@@ -190,6 +194,7 @@ class ExcBody3_10(ControlFlowTemplate):
             return x
         return node
 
+
 class NamedExc3_10(ExcBody3_10):
     template = T(
         header=N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST")),
@@ -226,6 +231,7 @@ class BareExcept3_10(Except3_10):
             {except_body}
         """
 
+
 class ExceptExc3_10(Except3_10):
     template = T(
         except_header=N("body", "falsejump"),
@@ -252,6 +258,7 @@ class ExceptExc3_10(Except3_10):
             {body}
         {falsejump}
         """
+
 
 @register_template(2, 50, *versions_from(3, 10))
 class TryFinally3_10(ControlFlowTemplate):
@@ -280,8 +287,6 @@ class TryFinally3_10(ControlFlowTemplate):
             f = BlockTemplate([f])
         if not isinstance(g, BlockTemplate):
             g = BlockTemplate([g])
-        #if isinstance(g.members[0], InstTemplate) and g.members[0].inst.opname == "PUSH_EXC_INFO":
-        #    g.members.pop(0)
         if isinstance(g.members[-1], InstTemplate) and g.members[-1].inst.opname == "RERAISE":
             g.members.pop()
         x = None
@@ -328,6 +333,7 @@ class TryFinally3_10(ControlFlowTemplate):
             after = []
 
         return list(chain(header, self.line("try:"), body, self.line("finally:"), in_finally, after))
+
 
 class BareExcept3_11(Except3_11):
     template = T(

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -118,6 +118,7 @@ class TryElse3_12(ControlFlowTemplate):
 @register_template(0, 1, (3, 10))
 class Try3_10(ControlFlowTemplate):
     template = T(
+        try_header=~N("try_body"),
         try_body=N("try_footer.", None, "except_body"),
         try_footer=~N("tail."),
         except_body=~N("tail.").of_subtemplate(Except3_10),
@@ -129,6 +130,7 @@ class Try3_10(ControlFlowTemplate):
             {
                 EdgeKind.Fall: "tail",
             },
+            "try_header",
             "try_body",
             "except_body",
             "try_footer",
@@ -138,6 +140,7 @@ class Try3_10(ControlFlowTemplate):
     @to_indented_source
     def to_indented_source():
         """
+        {try_header}
         try:
             {try_body}
         {except_body}
@@ -146,6 +149,7 @@ class Try3_10(ControlFlowTemplate):
 @register_template(0, 0, (3, 10))
 class TryElse3_10(ControlFlowTemplate):
     template = T(
+        try_header=N("try_body"),
         try_body=N("try_footer.", None, "except_body"),
         try_footer=N("else_body").with_in_deg(1),
         except_body=N("tail.").with_in_deg(1).of_subtemplate(Except3_10),
@@ -158,6 +162,7 @@ class TryElse3_10(ControlFlowTemplate):
             {
                 EdgeKind.Fall: "tail",
             },
+            "try_header",
             "try_body",
             "try_footer",
             "except_body",
@@ -168,6 +173,7 @@ class TryElse3_10(ControlFlowTemplate):
     @to_indented_source
     def to_indented_source():
         """
+        {try_header}
         try:
             {try_body}
         {except_body}
@@ -200,7 +206,7 @@ class NamedExc3_10(ExcBody3_10):
 
 class BareExcept3_10(Except3_10):
     template = T(
-        except_body=~N("tail.", None).of_type(BlockTemplate).with_cond(with_instructions("POP_EXCEPT"), with_instructions("RAISE_VARARGS")),
+        except_body=~N("tail.", None).of_type(BlockTemplate).with_cond(with_instructions("POP_EXCEPT")),
         tail=N.tail(),
     )
 


### PR DESCRIPTION
This commit adds some adjustments to the previous try-except work on 3.10 (syncing with upstream) and adds the base `try: finally` (i.e. no except or else). Performance on the 1k test cases is now ~72.34%.