### PR TITLE
Try-Except 3.6/3.7/3.8 + 3.9/3.10 + 3.11/3.12/3.13 test cases

### DIFF
--- a/pylingual/control_flow_reconstruction/templates/Conditional.py
+++ b/pylingual/control_flow_reconstruction/templates/Conditional.py
@@ -1,5 +1,5 @@
 from ..cft import ControlFlowTemplate, EdgeKind, register_template
-from ..utils import T, N, defer_source_to, run_is, exact_instructions, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions
+from ..utils import T, N, defer_source_to, run_is, with_instructions, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions
 
 
 @register_template(1, 40)
@@ -46,7 +46,7 @@ class IfThen(ControlFlowTemplate):
 class Assertion(ControlFlowTemplate):
     template = T(
         assertion=~N("fail", "tail"),
-        fail=+N().with_cond(starting_instructions("LOAD_ASSERTION_ERROR"), exact_instructions("LOAD_GLOBAL", "RAISE_VARARGS")),
+        fail=+N().with_cond(starting_instructions("LOAD_ASSERTION_ERROR"), with_instructions("LOAD_GLOBAL", "RAISE_VARARGS")),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Conditional.py
+++ b/pylingual/control_flow_reconstruction/templates/Conditional.py
@@ -1,5 +1,5 @@
 from ..cft import ControlFlowTemplate, EdgeKind, register_template
-from ..utils import T, N, defer_source_to, run_is, with_instructions, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions
+from ..utils import T, N, defer_source_to, run_is, with_instructions, has_instval, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions
 
 
 @register_template(1, 40)
@@ -46,7 +46,7 @@ class IfThen(ControlFlowTemplate):
 class Assertion(ControlFlowTemplate):
     template = T(
         assertion=~N("fail", "tail"),
-        fail=+N().with_cond(starting_instructions("LOAD_ASSERTION_ERROR"), with_instructions("LOAD_GLOBAL", "RAISE_VARARGS")),
+        fail=+N().with_cond(starting_instructions("LOAD_ASSERTION_ERROR"), has_instval("LOAD_GLOBAL", argval = "AssertionError")),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Conditional.py
+++ b/pylingual/control_flow_reconstruction/templates/Conditional.py
@@ -1,5 +1,5 @@
 from ..cft import ControlFlowTemplate, EdgeKind, register_template
-from ..utils import T, N, defer_source_to, run_is, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions
+from ..utils import T, N, defer_source_to, run_is, exact_instructions, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions
 
 
 @register_template(1, 40)
@@ -46,7 +46,7 @@ class IfThen(ControlFlowTemplate):
 class Assertion(ControlFlowTemplate):
     template = T(
         assertion=~N("fail", "tail"),
-        fail=+N().with_cond(starting_instructions("LOAD_ASSERTION_ERROR")),
+        fail=+N().with_cond(starting_instructions("LOAD_ASSERTION_ERROR"), exact_instructions("LOAD_GLOBAL", "RAISE_VARARGS")),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -279,6 +279,10 @@ class TryFinally3_11(ControlFlowTemplate):
     def to_indented_source(self, source: SourceContext) -> list[SourceLine]:
         header = source[self.try_header]
         body = source[self.try_body, 1]
+        if isinstance(self.try_header, (Try3_11, TryElse3_11)) and self.members['try_body'] is None:
+            s = header
+        else:
+            s = chain(header, self.line('try:'), body)
 
         if isinstance(self.finally_body, BlockTemplate):
             i = self.cutoff + 1
@@ -288,7 +292,7 @@ class TryFinally3_11(ControlFlowTemplate):
             in_finally = source[self.finally_body, 1]
             after = []
 
-        return list(chain(header, self.line("try:"), body, self.line("finally:"), in_finally, after))
+        return list(chain(s, self.line("finally:"), in_finally, after))
 
 
 class Except3_9(ControlFlowTemplate):

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -542,10 +542,10 @@ class Except3_6(ControlFlowTemplate):
 @register_template(0, 0, (3, 6), (3, 7), (3, 8))
 class Try3_6(ControlFlowTemplate):
     template = T(
-        try_header=N("try_body").with_cond(without_top_level_instructions("SETUP_WITH")),
+        try_header=~N("try_body").with_cond(without_top_level_instructions("SETUP_WITH")),
         try_body=N("try_footer", None, "except_body"),
-        try_footer=N("tail."),
-        except_body=N("tail.").with_in_deg(1).of_subtemplate(Except3_6),
+        try_footer=~N("tail."),
+        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_6),
         tail=N.tail(),
     )
 
@@ -662,8 +662,8 @@ class TryElse3_6(ControlFlowTemplate):
 
 class BareExcept3_6(Except3_6):
     template = T(
-        except_body=N("tail."),
-        tail=N.tail(),
+        except_body=~N("tail."),
+        tail=~N.tail(),
     )
 
     try_match = make_try_match(

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -631,8 +631,8 @@ class TryElse3_6(ControlFlowTemplate):
         try_header=~N("try_body").with_cond(exact_instructions("SETUP_EXCEPT"), exact_instructions("SETUP_FINALLY")),
         try_body=N("try_footer.", None, "except_body"),
         try_footer=~N("else_body").with_in_deg(1),
-        except_body=~N("tail").with_in_deg(1).of_subtemplate(Except3_6),
-        else_body=~N("tail").with_in_deg(1),
+        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_6),
+        else_body=~N("tail.").with_in_deg(1),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -38,20 +38,6 @@ class Except3_11(ControlFlowTemplate):
             return x
 
 
-class Except3_9(ControlFlowTemplate):
-    @classmethod
-    @override
-    def try_match(cls, cfg, node) -> ControlFlowTemplate | None:
-        if [x.opname for x in node.get_instructions()] == ["RERAISE"]:
-            return node
-        if x := ExceptExc3_9.try_match(cfg, node):
-            return x
-        if x := BareExcept3_9.try_match(cfg, node):
-            return x
-        if isinstance(node, Except3_9):
-            return node
-
-
 @register_template(0, 0, *versions_from(3, 11))
 class Try3_11(ControlFlowTemplate):
     template = T(
@@ -305,6 +291,20 @@ class TryFinally3_11(ControlFlowTemplate):
         return list(chain(header, self.line("try:"), body, self.line("finally:"), in_finally, after))
 
 
+class Except3_9(ControlFlowTemplate):
+    @classmethod
+    @override
+    def try_match(cls, cfg, node) -> ControlFlowTemplate | None:
+        if [x.opname for x in node.get_instructions()] == ["RERAISE"]:
+            return node
+        if x := ExceptExc3_9.try_match(cfg, node):
+            return x
+        if x := BareExcept3_9.try_match(cfg, node):
+            return x
+        if isinstance(node, Except3_9):
+            return node
+        
+
 @register_template(0, 1, (3, 9), (3, 10))
 class Try3_9(ControlFlowTemplate):
     template = T(
@@ -385,7 +385,7 @@ class ExcBody3_9(ControlFlowTemplate):
 class NamedExc3_9(ExcBody3_9):
     template = T(
         header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST")),
-        body=N("normal_cleanup", None, "exception_cleanup"),
+        body=N("normal_cleanup.", None, "exception_cleanup"),
         normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
         exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
         tail=N.tail(),

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -108,7 +108,7 @@ class TryElse3_11(ControlFlowTemplate):
 
 class BareExcept3_11(Except3_11):
     template = T(
-        except_body=N("except_footer", None, "reraise"),
+        except_body=N("except_footer.", None, "reraise").with_cond(without_top_level_instructions("RERAISE")),
         except_footer=~N("tail.").with_in_deg(1).with_cond(starting_instructions("POP_EXCEPT")),
         reraise=reraise,
         tail=N.tail(),
@@ -219,14 +219,14 @@ class TryFinally3_11(ControlFlowTemplate):
         try_header=N("try_body"),
         try_body=N("finally_body", None, "fail_body"),
         finally_body=~N("tail.").with_in_deg(1).with_cond(no_back_edges),
-        fail_body=N(E.exc("reraise")),
+        fail_body=N(E.exc("reraise")).with_cond(ending_instructions("POP_TOP", "RERAISE")),
         reraise=reraise,
         tail=N.tail(),
     )
     template2 = T(
         try_except=N("finally_body", None, "fail_body").of_type(Try3_11, TryElse3_11),
         finally_body=~N("tail.").with_in_deg(1).with_cond(no_back_edges),
-        fail_body=N(E.exc("reraise")),
+        fail_body=N(E.exc("reraise")).with_cond(ending_instructions("POP_TOP", "RERAISE")),
         reraise=reraise,
         tail=N.tail(),
     )

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -388,10 +388,10 @@ class ExcBody3_9(ControlFlowTemplate):
 
 class NamedExc3_9(ExcBody3_9):
     template = T(
-        header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST")),
+        header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST"), with_instructions("POP_TOP", "STORE_NAME")),
         body=N("normal_cleanup.", None, "exception_cleanup"),
-        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
-        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
+        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
+        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
         tail=N.tail(),
     )
 
@@ -582,10 +582,10 @@ class ExcBody3_6(ControlFlowTemplate):
 
 class NamedExc3_6(ExcBody3_6):
     template = T(
-        header=~N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST")),
+        header=~N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST"), with_instructions("POP_TOP", "STORE_NAME")),
         body=N("normal_cleanup.", None, "exception_cleanup"),
         normal_cleanup=~N("exception_cleanup."),
-        exception_cleanup=~N("tail.").with_cond(with_instructions("LOAD_CONST", "STORE_FAST")),
+        exception_cleanup=~N("tail.").with_cond(with_instructions("LOAD_CONST", "STORE_FAST"), with_instructions("LOAD_CONST", "STORE_NAME")),
         tail=N.tail()
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -340,12 +340,12 @@ class Try3_9(ControlFlowTemplate):
 @register_template(0, 0, (3, 9), (3, 10))
 class TryElse3_9(ControlFlowTemplate):
     template = T(
-        try_header=N("try_body"),
+        try_header=~N("try_body"),
         try_body=N("try_footer.", None, "except_body"),
-        try_footer=N("else_body").with_in_deg(1),
-        except_body=N("tail.").with_in_deg(1).of_subtemplate(Except3_9),
+        try_footer=~N("else_body").with_in_deg(1),
+        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_9),
         else_body=~N("tail.").with_in_deg(1),
-        tail=N.tail(),
+        tail=~N.tail(),
     )
 
     try_match = revert_on_fail(

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -390,8 +390,8 @@ class NamedExc3_9(ExcBody3_9):
     template = T(
         header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST"), with_instructions("POP_TOP", "STORE_NAME")),
         body=N("normal_cleanup.", None, "exception_cleanup"),
-        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
-        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
+        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_NAME")),
+        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_NAME")),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -627,7 +627,7 @@ class ExceptExc3_6(Except3_6):
 @register_template(0, 0, (3, 6), (3, 7), (3, 8))
 class TryElse3_6(ControlFlowTemplate):
     template = T(
-        try_header=N("try_body"),
+        try_header=N("try_body").with_cond(exact_instructions("SETUP_EXCEPT"), exact_instructions("SETUP_FINALLY")),
         try_body=N("try_footer.", None, "except_body"),
         try_footer=N("else_body").with_in_deg(1),
         except_body=N("tail").with_in_deg(1).of_subtemplate(Except3_6),

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -583,7 +583,7 @@ class ExcBody3_6(ControlFlowTemplate):
 class NamedExc3_6(ExcBody3_6):
     template = T(
         header=N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST")),
-        body=N("normal_cleanup", None, "exception_cleanup"),
+        body=N("normal_cleanup.", None, "exception_cleanup"),
         normal_cleanup=N("exception_cleanup."),
         exception_cleanup=N.tail().with_cond(with_instructions("LOAD_CONST", "STORE_FAST")),
     )

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -585,7 +585,8 @@ class NamedExc3_6(ExcBody3_6):
         header=N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST")),
         body=N("normal_cleanup.", None, "exception_cleanup"),
         normal_cleanup=N("exception_cleanup."),
-        exception_cleanup=N.tail().with_cond(with_instructions("LOAD_CONST", "STORE_FAST")),
+        exception_cleanup=N("tail.").with_cond(with_instructions("LOAD_CONST", "STORE_FAST")),
+        tail=N.tail()
     )
 
     try_match = make_try_match({EdgeKind.Fall: "tail"}, "exception_cleanup", "header", "body", "normal_cleanup")
@@ -600,7 +601,7 @@ class ExceptExc3_6(Except3_6):
             ending_instructions("COMPARE_OP", "POP_JUMP_FORWARD_IF_FALSE")
         ),
         except_body=N("tail.", None).of_subtemplate(ExcBody3_6).with_in_deg(1),
-        no_match=N("tail?", None).of_subtemplate(Except3_6),
+        no_match=N.tail().of_subtemplate(Except3_6),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/utils.py
+++ b/pylingual/control_flow_reconstruction/utils.py
@@ -118,6 +118,18 @@ def has_incoming_edge_of_categories(*categories: str):
         return False
     return check
 
+
+def has_instval(opname: str, argval : Any):
+    def check_instructions(cfg: CFG, node: ControlFlowTemplate | None) -> bool:
+        ops = {x.opname : x.argval for x in node.get_instructions()}
+        for op in ops:
+            if ops[op] == argval:
+                return True
+        return False
+    
+    return check_instructions
+
+
 def run_is(n: int):
     def check_run(cfg: CFG, node: ControlFlowTemplate | None) -> bool:
         return cfg.run == n

--- a/pylingual/control_flow_reconstruction/utils.py
+++ b/pylingual/control_flow_reconstruction/utils.py
@@ -121,9 +121,8 @@ def has_incoming_edge_of_categories(*categories: str):
 
 def has_instval(opname: str, argval : Any):
     def check_instructions(cfg: CFG, node: ControlFlowTemplate | None) -> bool:
-        ops = {x.opname : x.argval for x in node.get_instructions()}
-        for op in ops:
-            if ops[op] == argval:
+        for x in node.get_instructions():
+            if x.opname == opname and x.argval == argval:
                 return True
         return False
     

--- a/test/TryExcept.py
+++ b/test/TryExcept.py
@@ -407,6 +407,14 @@ def z_TryExceptReturn():
     except:
         print(2)
 
+def z1_TryExceptReturn():
+    try:
+        print(1)
+        return 2
+    except:
+        print(2)
+        return 3
+
 def aa_TryExceptReturnMulti():
     try:
         print(1)
@@ -422,6 +430,14 @@ def ab_TryExceptReturnNamed():
         return 2
     except A as a:
         print(2)
+
+def ab1_TryExceptReturnNamed():
+    try:
+        print(1)
+        return 2
+    except A as a:
+        print(2)
+        return 3
 
 def ac_TryFinallyBareFallthrough():
     try:

--- a/test/TryExcept.py
+++ b/test/TryExcept.py
@@ -1,218 +1,11 @@
-def TryExcept():
+def a_TryExcept():
     try:
         print(1)
     except:
        print(2)
     print(3)
 
-def TryExceptMulti():
-    try:
-        print(1)
-    except a:
-       print(2)
-    except b:
-       print(3)
-    except c:
-       print(4)
-    print(5)
-
-def TryExceptMultiFallback():
-    try:
-        print(1)
-    except a:
-       print(2)
-    except b:
-       print(3)
-    except:
-       print(4)
-    print(5)
-
-def TryExceptMultiNamed():
-    try:
-        print(1)
-    except A as a:
-       print(2)
-    except B as b:
-       print(3)
-    except C as c:
-       print(4)
-    print(5)
-
-def TryExceptMultiNamedFallback():
-    try:
-        print(1)
-    except A as a:
-       print(2)
-    except B as b:
-       print(3)
-    except:
-       print(4)
-    print(5)
-
-def TryExceptMultiNamedAndUnnamed():
-    try:
-        print(1)
-    except A as a:
-       print(2)
-    except b:
-       print(3)
-    except:
-       print(4)
-    print(5)
-
-def TryExceptElseBare():
-    try:
-        print(1)
-    except:
-        print(2)
-    else:
-        print(3)
-    print(4)
-
-def TryExceptElseMulti():
-    try:
-        print(1)
-    except a:
-        print(2)
-    except b:
-        print(3)
-    else:
-        print(4)
-    print(5)
-
-def TryExceptElseMultiFallback():
-    try:
-        print(1)
-    except a:
-        print(2)
-    except b:
-        print(3)
-    except:
-        print(4)
-    else:
-        print(5)
-    print(6)
-
-def TryExceptElseNamed():
-    try:
-        print(1)
-    except A as a:
-        print(2)
-    except B as b:
-        print(3)
-    else:
-        print(4)
-    print(5)
-
-def TryExceptElseMultiNamedAndUnnamed():
-    try:
-        print(1)
-    except A as a:
-       print(2)
-    except b:
-       print(3)
-    except:
-       print(4)
-    else:
-        print(5)
-    print(6)
-
-def TryFinallyBare():
-    try:
-        print(1)
-    finally:
-        print(2)
-    print(3)
-
-def TryExceptFinallyBare():
-    try:
-        print(1)
-    except:
-        print(2)
-    finally:
-        print(3)
-    print(4)
-##### NOT YET IMPLEMENTED #####
-##### crashes cflow.py #####
-##def TryExceptFinallyBareSpecific():
-##    try:
-##        print(1)
-##    except a:
-##        print(2)
-##    finally:
-##        print(3)
-##    print(4)
-##
-##def TryExceptMultiFinally():
-##    try:
-##        print(1)
-##    except a:
-##        print(2)
-##    except b:
-##        print(3)
-##    finally:
-##        print(4)
-##    print(5)
-##
-## Broken
-##def TryExceptMultiFallbackFinally():
-##    try:
-##        print(1)
-##    except a:
-##        print(2)
-##    except:
-##        print(3)
-##    finally:
-##        print(4)
-##    print(5)
-
-def TryExceptMultiNamedFinally():
-    try:
-        print(1)
-    except A as a:
-        print(2)
-    except B as b:
-        print(3)
-    finally:
-        print(4)
-    print(5)
-
-def TryExceptMultiNamedFallbackFinally():
-    try:
-        print(1)
-    except A as a:
-        print(2)
-    except:
-        print(3)
-    finally:
-        print(4)
-    print(5)
-
-def TryExceptMultiNamedAndUnnamedFinally():
-    try:
-        print(1)
-    except A as a:
-       print(2)
-    except b:
-       print(3)
-    except:
-       print(4)
-    finally:
-        print(5)
-    print(6)
-
-def TryExceptElseFinallyBare():
-    try:
-        print(1)
-    except:
-        print(2)
-    else:
-        print(3)
-    finally:
-        print(4)
-    print(5)
-
-def TryExceptBareNested():
+def b_TryExceptBareNested():
     try:
         print(1)
     except:
@@ -222,47 +15,41 @@ def TryExceptBareNested():
         except:
             print(4)
 
-def TryExceptReturn():
-    try:
-        print(1)
-        return 2
-    except:
-        print(2)
-
-# Not currently working, see https://github.com/syssec-utd/pylingual/issues/24#issuecomment-3005215427
-def TryExceptRaise():
+def b1_TryExceptBareNestedFallthrough():
     try:
         print(1)
     except:
-        print(2)
-        raise Exc
-
-def TryExceptRaiseNamed():
-    try:
-        print(1)
-    except A as a:
-        print(2)
-        raise Exc
-
-### Expected to fail on 3.10- has the same issue as TryExceptFinally
-def TryExceptBareNestedNamed():
-    try:
-        print(1)
-    except A as a:
         print(2)
         try:
             print(3)
         except:
             print(4)
+        print(5)
 
-def TryExceptReturnNamed():
+def b2_TryExceptBareNestedEarlyFallthrough():
     try:
         print(1)
-        return 2
-    except A as a:
+    except:
         print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+    print(5)
 
-def TryExceptBareNestedMulti():
+def b3_TryExceptBareNestedDoubleFallthrough():
+    try:
+        print(1)
+    except:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+        print(5)
+    print(6)
+
+def c_TryExceptBareMultiNested():
     try:
         print(1)
     except a:
@@ -278,7 +65,349 @@ def TryExceptBareNestedMulti():
         except:
             print(7)
 
-def TryExceptReturnMulti():
+def c1_TryExceptBareMultiNestedFallthrough():
+    try:
+        print(1)
+    except a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+        print(5)
+    except b:
+        print(6)
+        try:
+            print(7)
+        except:
+            print(8)
+
+def c2_TryExceptBareMultiNestedFallthrough2():
+    try:
+        print(1)
+    except a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+        print(5)
+    except b:
+        print(6)
+        try:
+            print(7)
+        except:
+            print(8)
+        print(9)
+
+def c3_TryExceptBareMultiNestedEarlyFallthrough():
+    try:
+        print(1)
+    except a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+    except b:
+        print(5)
+        try:
+            print(6)
+        except:
+            print(7)
+    print(8)
+
+def c4_TryExceptBareMultiNestedAllFallthrough():
+    try:
+        print(1)
+    except a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+        print(5)
+    except b:
+        print(6)
+        try:
+            print(7)
+        except:
+            print(8)
+        print(9)
+    print(10)
+
+def d_TryExceptBareNestedNamed():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+
+def d1_TryExceptBareNestedNamedFallthrough():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+        print(5)
+
+def d2_TryExceptBareNestedNamedEarlyFallthrough():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+    print(5)
+
+def d3_TryExceptBareNestedNamedDoubleFallthrough():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+        try:
+            print(3)
+        except:
+            print(4)
+        print(5)
+    print(6)
+
+def e_TryExceptElseBare():
+    try:
+        print(1)
+    except:
+        print(2)
+    else:
+        print(3)
+    print(4)
+
+def f_TryExceptElseFinallyBare():
+    try:
+        print(1)
+    except:
+        print(2)
+    else:
+        print(3)
+    finally:
+        print(4)
+    print(5)
+
+def g_TryExceptElseMulti():
+    try:
+        print(1)
+    except a:
+        print(2)
+    except b:
+        print(3)
+    else:
+        print(4)
+    print(5)
+
+def h_TryExceptElseMultiFallback():
+    try:
+        print(1)
+    except a:
+        print(2)
+    except b:
+        print(3)
+    except:
+        print(4)
+    else:
+        print(5)
+    print(6)
+
+def i_TryExceptElseMultiNamedAndUnnamed():
+    try:
+        print(1)
+    except A as a:
+       print(2)
+    except b:
+       print(3)
+    except:
+       print(4)
+    else:
+        print(5)
+    print(6)
+
+def j_TryExceptElseNamed():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+    except B as b:
+        print(3)
+    else:
+        print(4)
+    print(5)
+
+def k_TryExceptFinallyBare():
+    try:
+        print(1)
+    except:
+        print(2)
+    finally:
+        print(3)
+    print(4)
+
+def l_TryExceptFinallyBareSpecific():
+   try:
+       print(1)
+   except a:
+       print(2)
+   finally:
+       print(3)
+   print(4)
+
+def m_TryExceptMulti():
+    try:
+        print(1)
+    except a:
+       print(2)
+    except b:
+       print(3)
+    except c:
+       print(4)
+    print(5)
+
+def n_TryExceptMultiFallback():
+    try:
+        print(1)
+    except a:
+       print(2)
+    except b:
+       print(3)
+    except:
+       print(4)
+    print(5)
+
+def o_TryExceptMultiFallbackFinally():
+   try:
+       print(1)
+   except a:
+       print(2)
+   except:
+       print(3)
+   finally:
+       print(4)
+   print(5)
+
+def p_TryExceptMultiNamed():
+    try:
+        print(1)
+    except A as a:
+       print(2)
+    except B as b:
+       print(3)
+    except C as c:
+       print(4)
+    print(5)
+
+def q_TryExceptMultiNamedAndUnnamed():
+    try:
+        print(1)
+    except A as a:
+       print(2)
+    except b:
+       print(3)
+    except:
+       print(4)
+    print(5)
+
+def r_TryExceptMultiNamedAndUnnamedFinally():
+    try:
+        print(1)
+    except A as a:
+       print(2)
+    except b:
+       print(3)
+    except:
+       print(4)
+    finally:
+        print(5)
+    print(6)
+
+def s_TryExceptMultiNamedFallback():
+    try:
+        print(1)
+    except A as a:
+       print(2)
+    except:
+       print(3)
+    print(4)
+
+def t_TryExceptMultiNamedFallbackFinally():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+    except:
+        print(3)
+    finally:
+        print(4)
+    print(5)
+
+def u_TryExceptMultiNamedFinally():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+    except B as b:
+        print(3)
+    finally:
+        print(4)
+    print(5)
+
+def v_TryExceptMultiFinally():
+   try:
+       print(1)
+   except a:
+       print(2)
+   except b:
+       print(3)
+   finally:
+       print(4)
+   print(5)
+
+def w_TryExceptRaise():
+    try:
+        print(1)
+    except:
+        print(2)
+        raise Exc
+
+def x_TryExceptRaiseMulti():
+    try:
+        print(1)
+    except a:
+        print(2)
+        raise Exc
+    except b:
+        print(3)
+        raise Exc
+
+def y_TryExceptRaiseNamed():
+    try:
+        print(1)
+    except A as a:
+        print(2)
+        raise Exc
+
+def z_TryExceptReturn():
+    try:
+        print(1)
+        return 2
+    except:
+        print(2)
+
+def aa_TryExceptReturnMulti():
     try:
         print(1)
         return 2
@@ -287,12 +416,22 @@ def TryExceptReturnMulti():
     except b:
         print(3)
 
-def TryExceptRaiseMulti():
+def ab_TryExceptReturnNamed():
     try:
         print(1)
-    except a:
+        return 2
+    except A as a:
         print(2)
-        raise Exc
-    except b:
-        print(3)
-        raise Exc
+
+def ac_TryFinallyBareFallthrough():
+    try:
+        print(1)
+    finally:
+        print(2)
+    print(3)
+
+def ad_TryFinallyBare():
+    try:
+        print(1)
+    finally:
+        print(2)

--- a/test/TryExcept.py
+++ b/test/TryExcept.py
@@ -424,6 +424,16 @@ def aa_TryExceptReturnMulti():
     except b:
         print(3)
 
+def aa1_TryExceptReturnMulti():
+    try:
+        print(1)
+        return 2
+    except a:
+        print(2)
+        return 3
+    except b:
+        print(3)
+
 def ab_TryExceptReturnNamed():
     try:
         print(1)


### PR DESCRIPTION
#19 #25 #41 

3.9: All known Try-Except test cases are completed 
3.10: Only d TryExceptBareNestedNamed test case incomplete (due to duplicate blocks)

3.11/3.12/3.13: b, c, d TryExceptBareNested test cases incomplete (due to duplicate blocks causing templates to not match) and z, aa, ab Return test cases incomplete due to the Return statement being in its own separate block which is unexpected to the template (compare test case a and z graph)

