### PR TITLE
Exception.py updated for 3.6/3.7/3.8 to handle additional tryFinally test cases

### DIFF
--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -38,20 +38,6 @@ class Except3_11(ControlFlowTemplate):
             return x
 
 
-class Except3_9(ControlFlowTemplate):
-    @classmethod
-    @override
-    def try_match(cls, cfg, node) -> ControlFlowTemplate | None:
-        if [x.opname for x in node.get_instructions()] == ["RERAISE"]:
-            return node
-        if x := ExceptExc3_9.try_match(cfg, node):
-            return x
-        if x := BareExcept3_9.try_match(cfg, node):
-            return x
-        if isinstance(node, Except3_9):
-            return node
-
-
 @register_template(0, 0, *versions_from(3, 11))
 class Try3_11(ControlFlowTemplate):
     template = T(
@@ -122,7 +108,7 @@ class TryElse3_11(ControlFlowTemplate):
 
 class BareExcept3_11(Except3_11):
     template = T(
-        except_body=N("except_footer", None, "reraise"),
+        except_body=N("except_footer.", None, "reraise").with_cond(without_top_level_instructions("RERAISE")),
         except_footer=~N("tail.").with_in_deg(1).with_cond(starting_instructions("POP_EXCEPT")),
         reraise=reraise,
         tail=N.tail(),
@@ -233,14 +219,14 @@ class TryFinally3_11(ControlFlowTemplate):
         try_header=N("try_body"),
         try_body=N("finally_body", None, "fail_body"),
         finally_body=~N("tail.").with_in_deg(1).with_cond(no_back_edges),
-        fail_body=N(E.exc("reraise")),
+        fail_body=N(E.exc("reraise")).with_cond(ending_instructions("POP_TOP", "RERAISE")),
         reraise=reraise,
         tail=N.tail(),
     )
     template2 = T(
         try_except=N("finally_body", None, "fail_body").of_type(Try3_11, TryElse3_11),
         finally_body=~N("tail.").with_in_deg(1).with_cond(no_back_edges),
-        fail_body=N(E.exc("reraise")),
+        fail_body=N(E.exc("reraise")).with_cond(ending_instructions("POP_TOP", "RERAISE")),
         reraise=reraise,
         tail=N.tail(),
     )
@@ -293,6 +279,10 @@ class TryFinally3_11(ControlFlowTemplate):
     def to_indented_source(self, source: SourceContext) -> list[SourceLine]:
         header = source[self.try_header]
         body = source[self.try_body, 1]
+        if isinstance(self.try_header, (Try3_11, TryElse3_11)) and self.members['try_body'] is None:
+            s = header
+        else:
+            s = chain(header, self.line('try:'), body)
 
         if isinstance(self.finally_body, BlockTemplate):
             i = self.cutoff + 1
@@ -302,8 +292,22 @@ class TryFinally3_11(ControlFlowTemplate):
             in_finally = source[self.finally_body, 1]
             after = []
 
-        return list(chain(header, self.line("try:"), body, self.line("finally:"), in_finally, after))
+        return list(chain(s, self.line("finally:"), in_finally, after))
 
+
+class Except3_9(ControlFlowTemplate):
+    @classmethod
+    @override
+    def try_match(cls, cfg, node) -> ControlFlowTemplate | None:
+        if [x.opname for x in node.get_instructions()] == ["RERAISE"]:
+            return node
+        if x := ExceptExc3_9.try_match(cfg, node):
+            return x
+        if x := BareExcept3_9.try_match(cfg, node):
+            return x
+        if isinstance(node, Except3_9):
+            return node
+        
 
 @register_template(0, 1, (3, 9), (3, 10))
 class Try3_9(ControlFlowTemplate):
@@ -340,12 +344,12 @@ class Try3_9(ControlFlowTemplate):
 @register_template(0, 0, (3, 9), (3, 10))
 class TryElse3_9(ControlFlowTemplate):
     template = T(
-        try_header=N("try_body"),
+        try_header=~N("try_body"),
         try_body=N("try_footer.", None, "except_body"),
-        try_footer=N("else_body").with_in_deg(1),
-        except_body=N("tail.").with_in_deg(1).of_subtemplate(Except3_9),
+        try_footer=~N("else_body").with_in_deg(1),
+        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_9),
         else_body=~N("tail.").with_in_deg(1),
-        tail=N.tail(),
+        tail=~N.tail(),
     )
 
     try_match = revert_on_fail(
@@ -385,7 +389,7 @@ class ExcBody3_9(ControlFlowTemplate):
 class NamedExc3_9(ExcBody3_9):
     template = T(
         header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST")),
-        body=N("normal_cleanup", None, "exception_cleanup"),
+        body=N("normal_cleanup.", None, "exception_cleanup"),
         normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
         exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
         tail=N.tail(),
@@ -538,10 +542,10 @@ class Except3_6(ControlFlowTemplate):
 @register_template(0, 0, (3, 6), (3, 7), (3, 8))
 class Try3_6(ControlFlowTemplate):
     template = T(
-        try_header=N("try_body").with_cond(without_top_level_instructions("SETUP_WITH")),
+        try_header=~N("try_body").with_cond(without_top_level_instructions("SETUP_WITH")),
         try_body=N("try_footer", None, "except_body"),
-        try_footer=N("tail."),
-        except_body=N("tail.").with_in_deg(1).of_subtemplate(Except3_6),
+        try_footer=~N("tail."),
+        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_6),
         tail=N.tail(),
     )
 
@@ -578,10 +582,11 @@ class ExcBody3_6(ControlFlowTemplate):
 
 class NamedExc3_6(ExcBody3_6):
     template = T(
-        header=N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST")),
-        body=N("normal_cleanup", None, "exception_cleanup"),
-        normal_cleanup=N("exception_cleanup."),
-        exception_cleanup=N.tail().with_cond(with_instructions("LOAD_CONST", "STORE_FAST")),
+        header=~N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST")),
+        body=N("normal_cleanup.", None, "exception_cleanup"),
+        normal_cleanup=~N("exception_cleanup."),
+        exception_cleanup=~N("tail.").with_cond(with_instructions("LOAD_CONST", "STORE_FAST")),
+        tail=N.tail()
     )
 
     try_match = make_try_match({EdgeKind.Fall: "tail"}, "exception_cleanup", "header", "body", "normal_cleanup")
@@ -591,12 +596,12 @@ class NamedExc3_6(ExcBody3_6):
 
 class ExceptExc3_6(Except3_6):
     template = T(
-        except_header=N("except_body", "no_match").with_cond(
+        except_header=~N("except_body", "no_match").with_cond(
             ending_instructions("COMPARE_OP", "POP_JUMP_IF_FALSE"),
             ending_instructions("COMPARE_OP", "POP_JUMP_FORWARD_IF_FALSE")
         ),
-        except_body=N("tail.", None).of_subtemplate(ExcBody3_6).with_in_deg(1),
-        no_match=N("tail?", None).of_subtemplate(Except3_6),
+        except_body=~N("tail.", None).of_subtemplate(ExcBody3_6).with_in_deg(1),
+        no_match=~N.tail().of_subtemplate(Except3_6),
         tail=N.tail(),
     )
 
@@ -623,10 +628,10 @@ class ExceptExc3_6(Except3_6):
 @register_template(0, 0, (3, 6), (3, 7), (3, 8))
 class TryElse3_6(ControlFlowTemplate):
     template = T(
-        try_header=N("try_body"),
+        try_header=~N("try_body").with_cond(exact_instructions("SETUP_EXCEPT"), exact_instructions("SETUP_FINALLY")),
         try_body=N("try_footer.", None, "except_body"),
-        try_footer=N("else_body").with_in_deg(1),
-        except_body=N("tail").with_in_deg(1).of_subtemplate(Except3_6),
+        try_footer=~N("else_body").with_in_deg(1),
+        except_body=~N("tail").with_in_deg(1).of_subtemplate(Except3_6),
         else_body=~N("tail").with_in_deg(1),
         tail=N.tail(),
     )
@@ -658,8 +663,8 @@ class TryElse3_6(ControlFlowTemplate):
 
 class BareExcept3_6(Except3_6):
     template = T(
-        except_body=N("tail."),
-        tail=N.tail(),
+        except_body=~N("tail."),
+        tail=~N.tail(),
     )
 
     try_match = make_try_match(
@@ -675,3 +680,54 @@ class BareExcept3_6(Except3_6):
         except:
             {except_body}
         """
+
+@register_template(2, 50, (3, 6), (3, 7), (3, 8))
+class TryFinally3_6(ControlFlowTemplate):
+    template = T(
+        try_header=N("try_body"),
+        try_body=N("finally_body", None, "fail_body"),
+        finally_body=~N("fail_body").with_in_deg(1).with_cond(no_back_edges),
+        fail_body=N("tail.").with_cond(with_instructions("POP_TOP", "END_FINALLY")),
+        tail=N.tail(),
+    )
+    template2 = T(
+        try_except=N("finally_tail", None, "fail_body").of_type(TryElse3_6, Try3_6),
+        finally_tail=N("finally_body", None, "fail_body"),
+        finally_body=~N("fail_body").with_in_deg(1).with_cond(no_back_edges),
+        fail_body=N("tail.").with_cond(with_instructions("POP_TOP", "END_FINALLY")),
+        tail=N.tail(),
+    )
+
+    cutoff: int
+
+    @classmethod
+    @override
+    def try_match(cls, cfg, node) -> ControlFlowTemplate | None:
+        mapping = cls.template.try_match(cfg, node)
+        if mapping is None:
+            mapping = cls.template2.try_match(cfg, node)
+            if mapping is None:
+                return None
+            mapping["try_header"] = mapping.pop("try_except")
+
+        cutoff = next((i for i, x in enumerate(mapping["fail_body"].get_instructions())), None)
+        if cutoff is None:
+            return None
+
+        template = condense_mapping(cls, cfg, mapping, "try_header", "try_body", "finally_body", "fail_body")
+        template.cutoff = cutoff
+        return template
+
+    def to_indented_source(self, source: SourceContext) -> list[SourceLine]:
+        header = source[self.try_header]
+        body = source[self.try_body, 1]
+
+        if isinstance(self.fail_body, BlockTemplate):
+            i = self.cutoff + 1
+            in_finally = source[BlockTemplate(self.fail_body.members[:i]), 1] if i > 0 else []
+            after = source[BlockTemplate(self.fail_body.members[i:])] if i < len(self.fail_body.members) else []
+        else:
+            in_finally = source[self.fail_body, 1]
+            after = []
+
+        return list(chain(header, self.line("try:"), body, self.line("finally:"), in_finally, after))

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -390,8 +390,8 @@ class NamedExc3_9(ExcBody3_9):
     template = T(
         header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST"), with_instructions("POP_TOP", "STORE_NAME")),
         body=N("normal_cleanup.", None, "exception_cleanup"),
-        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
-        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
+        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_NAME")),
+        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_NAME")),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -11,6 +11,7 @@ from ..utils import (
     condense_mapping,
     defer_source_to,
     with_instructions,
+    without_instructions,
     ending_instructions,
     exact_instructions,
     no_back_edges,
@@ -630,8 +631,8 @@ class TryElse3_6(ControlFlowTemplate):
     template = T(
         try_header=~N("try_body").with_cond(exact_instructions("SETUP_EXCEPT"), exact_instructions("SETUP_FINALLY")),
         try_body=N("try_footer.", None, "except_body"),
-        try_footer=~N("else_body").with_in_deg(1),
-        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_6),
+        try_footer=~N("else_body").with_in_deg(1),  
+        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_6).with_cond(without_instructions("RETURN_VALUE")),
         else_body=~N("tail.").with_in_deg(1),
         tail=N.tail(),
     )
@@ -658,6 +659,36 @@ class TryElse3_6(ControlFlowTemplate):
         {except_body}
         else:
             {else_body}
+        """
+
+@register_template(0, 0, (3, 6), (3, 7), (3, 8))
+class ReturnFinally3_6(ControlFlowTemplate):
+    template = T(
+        try_header=~N("try_body").with_cond(exact_instructions("SETUP_FINALLY")),
+        try_body=N(None, None, "fail_body").with_cond(with_instructions("LOAD_CONST","RETURN_VALUE")),
+        fail_body=~N("tail."),
+        tail=N.tail(),
+    )
+
+    try_match = revert_on_fail(
+        make_try_match(
+            {
+                EdgeKind.Fall: "tail",
+            },
+            "try_header",
+            "try_body",
+            "fail_body",
+        )
+    )
+
+    @to_indented_source
+    def to_indented_source():
+        """
+        {try_header}
+        try:
+            {try_body}
+        finally:
+            {fail_body}
         """
 
 
@@ -691,12 +722,13 @@ class TryFinally3_6(ControlFlowTemplate):
         tail=N.tail(),
     )
     template2 = T(
-        try_except=N("finally_tail", None, "fail_body").of_type(TryElse3_6, Try3_6),
+        try_except=N("finally_tail", None, "fail_body").of_type(TryElse3_6, Try3_6, ReturnFinally3_6),
         finally_tail=N("finally_body", None, "fail_body"),
         finally_body=~N("fail_body").with_in_deg(1).with_cond(no_back_edges),
         fail_body=N("tail.").with_cond(with_instructions("POP_TOP", "END_FINALLY"),with_instructions("LOAD_CONST", "RETURN_VALUE")),
         tail=N.tail(),
     )
+    
 
     cutoff: int
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -388,10 +388,10 @@ class ExcBody3_9(ControlFlowTemplate):
 
 class NamedExc3_9(ExcBody3_9):
     template = T(
-        header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST")),
+        header=~N("body", None).with_cond(with_instructions("POP_TOP", "STORE_FAST"), with_instructions("POP_TOP", "STORE_NAME")),
         body=N("normal_cleanup.", None, "exception_cleanup"),
-        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
-        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST")),
+        normal_cleanup=~N("tail.").with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
+        exception_cleanup=~N.tail().with_cond(with_instructions("STORE_FAST", "DELETE_FAST"), with_instructions("STORE_NAME", "DELETE_FAST")),
         tail=N.tail(),
     )
 
@@ -582,10 +582,10 @@ class ExcBody3_6(ControlFlowTemplate):
 
 class NamedExc3_6(ExcBody3_6):
     template = T(
-        header=~N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST")),
+        header=~N("body", None).with_cond(starting_instructions("POP_TOP", "STORE_FAST"), with_instructions("POP_TOP", "STORE_NAME")),
         body=N("normal_cleanup.", None, "exception_cleanup"),
         normal_cleanup=~N("exception_cleanup."),
-        exception_cleanup=~N("tail.").with_cond(with_instructions("LOAD_CONST", "STORE_FAST")),
+        exception_cleanup=~N("tail.").with_cond(with_instructions("LOAD_CONST", "STORE_FAST"), with_instructions("LOAD_CONST", "STORE_NAME")),
         tail=N.tail()
     )
 
@@ -631,8 +631,8 @@ class TryElse3_6(ControlFlowTemplate):
         try_header=~N("try_body").with_cond(exact_instructions("SETUP_EXCEPT"), exact_instructions("SETUP_FINALLY")),
         try_body=N("try_footer.", None, "except_body"),
         try_footer=~N("else_body").with_in_deg(1),
-        except_body=~N("tail").with_in_deg(1).of_subtemplate(Except3_6),
-        else_body=~N("tail").with_in_deg(1),
+        except_body=~N("tail.").with_in_deg(1).of_subtemplate(Except3_6),
+        else_body=~N("tail.").with_in_deg(1),
         tail=N.tail(),
     )
 

--- a/pylingual/control_flow_reconstruction/templates/Exception.py
+++ b/pylingual/control_flow_reconstruction/templates/Exception.py
@@ -687,14 +687,14 @@ class TryFinally3_6(ControlFlowTemplate):
         try_header=N("try_body"),
         try_body=N("finally_body", None, "fail_body"),
         finally_body=~N("fail_body").with_in_deg(1).with_cond(no_back_edges),
-        fail_body=N("tail.").with_cond(with_instructions("POP_TOP", "END_FINALLY")),
+        fail_body=N("tail.").with_cond(with_instructions("POP_TOP", "END_FINALLY"),with_instructions("LOAD_CONST", "RETURN_VALUE")),
         tail=N.tail(),
     )
     template2 = T(
         try_except=N("finally_tail", None, "fail_body").of_type(TryElse3_6, Try3_6),
         finally_tail=N("finally_body", None, "fail_body"),
         finally_body=~N("fail_body").with_in_deg(1).with_cond(no_back_edges),
-        fail_body=N("tail.").with_cond(with_instructions("POP_TOP", "END_FINALLY")),
+        fail_body=N("tail.").with_cond(with_instructions("POP_TOP", "END_FINALLY"),with_instructions("LOAD_CONST", "RETURN_VALUE")),
         tail=N.tail(),
     )
 
@@ -731,3 +731,4 @@ class TryFinally3_6(ControlFlowTemplate):
             after = []
 
         return list(chain(header, self.line("try:"), body, self.line("finally:"), in_finally, after))
+        

--- a/test/TryExcept.py
+++ b/test/TryExcept.py
@@ -132,39 +132,37 @@ def TryExceptFinallyBare():
     finally:
         print(3)
     print(4)
-##### NOT YET IMPLEMENTED #####
-##### crashes cflow.py #####
-##def TryExceptFinallyBareSpecific():
-##    try:
-##        print(1)
-##    except a:
-##        print(2)
-##    finally:
-##        print(3)
-##    print(4)
-##
-##def TryExceptMultiFinally():
-##    try:
-##        print(1)
-##    except a:
-##        print(2)
-##    except b:
-##        print(3)
-##    finally:
-##        print(4)
-##    print(5)
-##
-## Broken
-##def TryExceptMultiFallbackFinally():
-##    try:
-##        print(1)
-##    except a:
-##        print(2)
-##    except:
-##        print(3)
-##    finally:
-##        print(4)
-##    print(5)
+
+def TryExceptFinallyBareSpecific():
+    try:
+        print(1)
+    except a:
+        print(2)
+    finally:
+        print(3)
+    print(4)
+
+def TryExceptMultiFinally():
+    try:
+        print(1)
+    except a:
+        print(2)
+    except b:
+        print(3)
+    finally:
+        print(4)
+    print(5)
+
+def TryExceptMultiFallbackFinally():
+    try:
+        print(1)
+    except a:
+        print(2)
+    except:
+        print(3)
+    finally:
+        print(4)
+    print(5)
 
 def TryExceptMultiNamedFinally():
     try:
@@ -229,7 +227,6 @@ def TryExceptReturn():
     except:
         print(2)
 
-# Not currently working, see https://github.com/syssec-utd/pylingual/issues/24#issuecomment-3005215427
 def TryExceptRaise():
     try:
         print(1)
@@ -244,7 +241,7 @@ def TryExceptRaiseNamed():
         print(2)
         raise Exc
 
-### Expected to fail on 3.10- has the same issue as TryExceptFinally
+
 def TryExceptBareNestedNamed():
     try:
         print(1)
@@ -296,3 +293,102 @@ def TryExceptRaiseMulti():
     except b:
         print(3)
         raise Exc
+
+def TryEmptryFinally():
+    try:
+        pass
+    finally:
+        print(1)
+
+def TryMultiple():
+    try:
+        print(1)
+    except:
+        print(2)
+
+    try:
+        print(3)
+    except:
+        print(4)
+
+def TryExceptElseTry():
+    try:
+        print(1)
+    except:
+        print(2)
+    else:
+        try:
+            print(3)
+        except:
+            print(4)
+
+def TryFinallyNestedExcept():
+    try:
+        print(1)
+    finally:
+        try:
+            print(2)
+        except:
+            print(3)
+
+def TryExceptTuple():
+    try:
+        print(1)
+    except (A, B):
+        print(2)
+
+def TryFinallyReturn():
+    try:
+        print(1)
+    finally:
+        return 2
+
+def TryReturnFinally():
+    try:
+        return 1
+    finally:
+        print(2)
+
+def TryReturnFinallyReturn():
+    try:
+        return 1
+    finally:
+        return 2
+    
+def TryExceptRaise():
+    try:
+        print(1)
+        return 2
+    except:
+        raise Exception()
+    
+#doesn't work
+'''
+def TryExceptReturnFinally():
+    try:
+        raise Exception()
+    except:
+        print(1)
+        return 2
+    finally:
+        print(3)
+'''
+    
+# Doesn't Work
+'''
+def TryFinallyRaise():
+    try:
+        print(1)
+        return 2
+    finally:
+        raise Exception()
+'''
+
+'''
+def TryLoopBreakFinally():
+    while True:
+        try:
+            break
+        finally:
+            print("finally")
+'''

--- a/test/TryExcept.py
+++ b/test/TryExcept.py
@@ -362,7 +362,6 @@ def TryExceptRaise():
     except:
         raise Exception()
     
-#doesn't work
 '''
 def TryExceptReturnFinally():
     try:
@@ -374,7 +373,6 @@ def TryExceptReturnFinally():
         print(3)
 '''
     
-# Doesn't Work
 '''
 def TryFinallyRaise():
     try:

--- a/test/TryExcept.py
+++ b/test/TryExcept.py
@@ -382,11 +382,3 @@ def TryFinallyRaise():
         raise Exception()
 '''
 
-'''
-def TryLoopBreakFinally():
-    while True:
-        try:
-            break
-        finally:
-            print("finally")
-'''


### PR DESCRIPTION
The 3.9/3.11 changes I got from Xinlong
The 3.6 changes are for the test cases I added at the bottom of test/TryExcept
Commented out test cases I'm still working on, all others work in 3.6/7/8