### PR TITLE
Python 3.14 CFlow & Misc

### DIFF
--- a/pylingual/control_flow_reconstruction/templates/Block.py
+++ b/pylingual/control_flow_reconstruction/templates/Block.py
@@ -66,7 +66,7 @@ class RemoveUnreachable(ControlFlowTemplate):
             return node
 
 
-@register_template(0, 0, (3, 12), (3, 13))
+@register_template(0, 0, *versions_from(3, 12))
 class JumpTemplate(ControlFlowTemplate):
     template = T(
         body=~N("jump", None).with_cond(without_instructions("CLEANUP_THROW")),

--- a/pylingual/control_flow_reconstruction/templates/Block.py
+++ b/pylingual/control_flow_reconstruction/templates/Block.py
@@ -89,7 +89,7 @@ class JumpTemplate(ControlFlowTemplate):
 
     try_match = make_try_match(
         {
-            EdgeKind.Fall: "tail",
+            EdgeKind.Jump: "tail",
             EdgeKind.TrueJump: "block",
         },
         "body",

--- a/pylingual/control_flow_reconstruction/templates/Conditional.py
+++ b/pylingual/control_flow_reconstruction/templates/Conditional.py
@@ -1,5 +1,5 @@
 from ..cft import ControlFlowTemplate, EdgeKind, MetaTemplate, register_template
-from ..utils import E, T, N, defer_source_to, has_some_lines, run_is, has_no_lines, with_instructions, exact_instructions, has_instval, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions, ending_instructions
+from ..utils import E, T, N, defer_source_to, has_some_lines, run_is, has_no_lines, versions_from, with_instructions, exact_instructions, has_instval, starting_instructions, to_indented_source, make_try_match, without_top_level_instructions, ending_instructions
 from .Loop import BreakTemplate, ContinueTemplate
 
 class EarlyRet(ControlFlowTemplate):
@@ -80,7 +80,7 @@ class IfElseJump(ControlFlowTemplate):
         """
 
 
-@register_template(1, 39, (3, 12), (3, 13))
+@register_template(1, 39, *versions_from(3, 12))
 class IfElseLoop(ControlFlowTemplate):
     template = T(
         if_header=~N("else_body", "if_body").with_cond(without_top_level_instructions("WITH_EXCEPT_START", "CHECK_EXC_MATCH", "FOR_ITER")),

--- a/pylingual/control_flow_reconstruction/templates/Generator.py
+++ b/pylingual/control_flow_reconstruction/templates/Generator.py
@@ -1,5 +1,5 @@
 from ..cft import ControlFlowTemplate, EdgeKind, MetaTemplate, register_template
-from ..utils import E, T, N, defer_source_to, ending_instructions, exact_instructions, no_back_edges, to_indented_source, make_try_match
+from ..utils import E, T, N, defer_source_to, ending_instructions, exact_instructions, no_back_edges, starting_instructions, to_indented_source, make_try_match
 
 
 @register_template(0, 0)
@@ -51,4 +51,20 @@ class Generator3_12(ControlFlowTemplate):
         """
         {entry}
         {body}
+        """
+
+@register_template(0, 0, (3, 14))
+class Generator3_14(ControlFlowTemplate):
+    template = T(
+        entry=N(E.exc("gen_cleanup")).with_cond(starting_instructions("RETURN_GENERATOR", "POP_TOP")),
+        gen_cleanup=N(E.meta("end")).with_cond(exact_instructions("CALL_INTRINSIC_1", "RERAISE")),
+        end=N().of_type(MetaTemplate),
+    )
+
+    try_match = make_try_match({EdgeKind.Fall: "end"}, "entry","gen_cleanup")
+
+    @to_indented_source
+    def to_indented_source():
+        """
+        {entry}
         """

--- a/pylingual/control_flow_reconstruction/templates/Loop.py
+++ b/pylingual/control_flow_reconstruction/templates/Loop.py
@@ -181,7 +181,7 @@ class WhileElse3_10(ControlFlowTemplate):
         """
 
 
-@register_template(0, 1, (3, 12), (3, 13))
+@register_template(0, 1, *versions_from(3, 12))
 class WhileElse3_12(ControlFlowTemplate):
     template = T(
         while_header=~N("while_body", "else_body"),

--- a/pylingual/control_flow_reconstruction/templates/Loop.py
+++ b/pylingual/control_flow_reconstruction/templates/Loop.py
@@ -522,7 +522,7 @@ class FixLoop(ControlFlowTemplate):
                     # Only remove edge if there are more than 2 incoming edges to avoid breaking other control flow structures
                     if cfg.in_degree(succ) > 2:
                         cfg.remove_edge(break_node, succ)
-                    elif cfg.in_degree(succ) <= 2:
+                    elif cfg.in_degree(succ) <= 2 and succ != cfg.end:
                         # Broken: conflicting cases where removing the edge would strand blocks
                         # but also match correctly to valid Break statement nodes
                         continue

--- a/pylingual/control_flow_reconstruction/templates/Loop.py
+++ b/pylingual/control_flow_reconstruction/templates/Loop.py
@@ -12,6 +12,7 @@ from ..utils import (
     is_not_type,
     no_back_edges,
     versions_below,
+    versions_except,
     versions_from,
     ending_instructions,
     has_no_lines,
@@ -29,10 +30,27 @@ if TYPE_CHECKING:
 
 
 
-@register_template(0, 1)
+@register_template(0, 1, *versions_below(3, 14))
 class ForLoop(ControlFlowTemplate):
     template = T(
         for_iter=~N("for_body", "tail"),
+        for_body=~N("for_iter").with_in_deg(1),
+        tail=N.tail().with_cond(is_not_type(LoopElse)),
+    )
+
+    try_match = make_try_match({EdgeKind.Fall: "tail"}, "for_iter", "for_body")
+
+    @to_indented_source
+    def to_indented_source():
+        """
+        {for_iter}
+            {for_body}
+        """
+
+@register_template(0, 1, *versions_from(3, 14))
+class ForLoop3_14(ControlFlowTemplate):
+    template = T(
+        for_iter=~N("for_body", "tail").with_cond(with_top_level_instructions("FOR_ITER")),
         for_body=~N("for_iter").with_in_deg(1),
         tail=N.tail().with_cond(is_not_type(LoopElse)),
     )
@@ -85,7 +103,7 @@ class LoopedReturn(ControlFlowTemplate):
             {for_body}
         """
 
-@register_template(0, 2, *versions_below(3, 10))
+@register_template(0, 2, *versions_except((3, 10), (3, 11), (3, 12), (3, 13)))
 class SelfLoop3_6(ControlFlowTemplate):
     template = T(
         loop_body=~N("loop_body", None)
@@ -241,6 +259,49 @@ class WhileIfElseLoop(ControlFlowTemplate):
                 {if_body}
             {else_body?else:}
                 {else_body}
+        """
+
+
+@register_template(1, 39, *versions_from(3, 14))
+class WhileLoop3_14(ControlFlowTemplate):
+    template = T(
+        if_header=~N("if_body", "else_body").with_cond(without_top_level_instructions("WITH_EXCEPT_START", "CHECK_EXC_MATCH", "FOR_ITER", "NOP")),
+        else_body=~N("tail.").with_cond(without_top_level_instructions("RERAISE", "END_FINALLY")).with_in_deg(1),
+        if_body=~N("if_header").with_in_deg(1),
+        tail=N.tail(),
+    )
+
+    try_match = make_try_match({EdgeKind.Fall: "tail"}, "if_header", "if_body", "else_body")
+
+    @to_indented_source
+    def to_indented_source():
+        """
+        {if_header}
+            {if_body}
+        {else_body?else:}
+            {else_body}
+        """
+
+
+@register_template(1, 39, *versions_from(3, 14))
+class WhileTrueLoop3_14(ControlFlowTemplate):
+    template = T(
+        if_header=~N("if_body", "else_body").with_cond(without_top_level_instructions("WITH_EXCEPT_START", "CHECK_EXC_MATCH", "FOR_ITER")).with_cond(starting_instructions("NOP")),
+        else_body=~N("tail.").with_cond(without_top_level_instructions("RERAISE", "END_FINALLY")).with_in_deg(1),
+        if_body=~N("if_header").with_in_deg(1),
+        tail=N.tail(),
+    )
+
+    try_match = make_try_match({EdgeKind.Fall: "tail"}, "if_header", "if_body", "else_body")
+
+    @to_indented_source
+    def to_indented_source():
+        """
+        while True:
+            {if_header}
+                {else_body}
+            {if_body?else:}
+                {if_body}
         """
 
 


### PR DESCRIPTION
3.14 Changes
- Adjusted various templates to fit version 3.14 (```JumpTemplate```, ```WhileElse```, etc)
- Added a ```Generator3_14``` template since 3.14 breaks the existing template
- While loop changes to adjust for 3.14 changes
- New loop templates (Could be somehow optimized?)

Misc
- ```JumpTemplate``` adjustment to avoid BlockTemplate matching after
- adjusting Loops for WhileElse control flow types 

Control Flow Evaluation (1000 files)
```
                               (Python 3.14)
                       Evaluation Movement Matrix                        
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃                ┃ To (Local) ┃ To (Local) ┃  To (Local)   ┃ To (Local) ┃
┃ From (8090d4c) ┃  Success   ┃  Failure   ┃ Compile Error ┃   Error    ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│        Success │    667     │     -      │       -       │     -      │
│        Failure │    +76     │     31     │      +1       │     -      │
│  Compile Error │    +50     │    +15     │      156      │     -      │
│          Error │     -      │     -      │       -       │     -      │
└────────────────┴────────────┴────────────┴───────────────┴────────────┘
```