### PR TITLE
Python 3.15 Support

### DIFF
--- a/dev_scripts/cflow.py
+++ b/dev_scripts/cflow.py
@@ -72,7 +72,11 @@ def run(file: Path, out_dir: Path, version: PythonVersion, print=False):
         if file.is_dir():
             file = next(file.iterdir())
 
-        in_src = normalize_source(file.read_text(), replace_docstrings=True)
+        raw_src = file.read_text()
+        try:
+            in_src = normalize_source(raw_src, replace_docstrings=True, version=version.as_tuple())
+        except SyntaxError:
+            in_src = raw_src
         src_lines = sanitize_lines(in_src.split("\n"))
         in_path = out_dir / "a.py"
         in_path.write_text(in_src, encoding="utf-8")

--- a/pylingual/decompiler_config.yaml
+++ b/pylingual/decompiler_config.yaml
@@ -96,3 +96,14 @@ v3.14:
     REPO: syssec-utd/py314-pylingual-v4-statement
     REVISION: main
     TOKENIZER: syssec-utd/py314-pylingual-v4-tok
+
+v3.15:
+  SEGMENTATION_MODEL:
+    REPO: syssec-utd/py315-pylingual-v2-segmenter
+    REVISION: main
+    TOKENIZER: syssec-utd/py315-pylingual-v2-tokenizer
+
+  STATEMENT_MODEL:
+    REPO: syssec-utd/py315-pylingual-v2-statement
+    REVISION: main
+    TOKENIZER: syssec-utd/py315-pylingual-v2-tok

--- a/pylingual/utils/generate_bytecode.py
+++ b/pylingual/utils/generate_bytecode.py
@@ -12,7 +12,7 @@ import shutil
 from pylingual.utils.version import PythonVersion
 
 
-UV_VERSIONS = {PythonVersion((3, x)) for x in range(8, 15)}
+UV_VERSIONS = {PythonVersion((3, x)) for x in range(8, 16)}
 
 
 class CompileError(Exception):

--- a/pylingual/utils/version.py
+++ b/pylingual/utils/version.py
@@ -1,4 +1,4 @@
-supported_tuples = [(3, x) for x in range(6, 15)]
+supported_tuples = [(3, x) for x in range(6, 16)]
 version_str = {f"{x[0]}{x[1]}": x for x in supported_tuples} | {
     f"{x[0]}.{x[1]}": x for x in supported_tuples
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,4 +103,5 @@ members = [
     "pylingual/tools",
 ]
 
-
+[tool.uv.sources]
+xdis = { git = "https://github.com/rocky/python-xdis" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,5 +103,4 @@ members = [
     "pylingual/tools",
 ]
 
-[tool.uv.sources]
-xdis = { git = "https://github.com/quinntyx/python-xdis", rev = "python-3.15-support" }
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,4 +104,4 @@ members = [
 ]
 
 [tool.uv.sources]
-xdis = { git = "https://github.com/jdw170000/python-xdis", rev = "python-3.14" }
+xdis = { git = "https://github.com/quinntyx/python-xdis", rev = "python-3.15-support" }

--- a/test/Python315.py
+++ b/test/Python315.py
@@ -1,0 +1,150 @@
+# PEP 798: Unpacking in comprehensions (3.15+)
+
+
+def a0_star_list_comp():
+    lists = [[1, 2], [3, 4], [5]]
+    [*L for L in lists]
+
+
+def a1_star_list_comp_nofallthru():
+    lists = [[1, 2], [3, 4], [5]]
+    [*L for L in lists]
+    print("end")
+
+
+def b0_star_set_comp():
+    sets = [{1, 2}, {2, 3}, {3, 4}]
+    {*s for s in sets}
+
+
+def b1_star_set_comp_nofallthru():
+    sets = [{1, 2}, {2, 3}, {3, 4}]
+    {*s for s in sets}
+    print("end")
+
+
+def c0_star_dict_comp():
+    dicts = [{'a': 1}, {'b': 2}]
+    {**d for d in dicts}
+
+
+def c1_star_dict_comp_nofallthru():
+    dicts = [{'a': 1}, {'b': 2}]
+    {**d for d in dicts}
+    print("end")
+
+
+def d0_star_gen_expr():
+    lists = [[1, 2], [3, 4]]
+    (*L for L in lists)
+
+
+def d1_star_gen_expr_nofallthru():
+    lists = [[1, 2], [3, 4]]
+    (*L for L in lists)
+    print("end")
+
+
+# PEP 798: Unpacking in comprehensions combined with control flow
+
+
+def e0_star_list_comp_in_if():
+    lists = [[1, 2], [3, 4]]
+    if lists:
+        [*L for L in lists]
+
+
+def e1_star_list_comp_in_if_nofallthru():
+    lists = [[1, 2], [3, 4]]
+    if lists:
+        [*L for L in lists]
+    print("end")
+
+
+def f0_star_list_comp_in_loop():
+    lists = [[1, 2], [3, 4]]
+    for _ in range(2):
+        [*L for L in lists]
+
+
+def f1_star_list_comp_in_loop_nofallthru():
+    lists = [[1, 2], [3, 4]]
+    for _ in range(2):
+        [*L for L in lists]
+    print("end")
+
+
+# Unary plus in match literal patterns (3.15+)
+
+
+def g0_match_unary_plus():
+    match x:
+        case +1:
+            print(1)
+
+
+def g1_match_unary_plus_fallthrough():
+    match x:
+        case +1:
+            print(1)
+    print(2)
+
+
+def h0_match_unary_plus_multi_case():
+    match x:
+        case +1:
+            print(1)
+        case +2:
+            print(2)
+        case _:
+            print(3)
+    print(4)
+
+
+def i0_match_unary_plus_with_guard():
+    match x:
+        case +1 if y > 0:
+            print(1)
+    print(2)
+
+
+# PEP 810: Lazy imports (3.15+) — module scope only
+# These are at module level since lazy imports are not allowed inside functions
+
+lazy import json
+lazy from pathlib import Path
+
+
+def j0_lazy_import_usage():
+    data = json.loads('{"key": "value"}')
+    print(data)
+
+
+def j1_lazy_import_usage_nofallthru():
+    data = json.loads('{"key": "value"}')
+    print(data)
+    print("end")
+
+
+def k0_lazy_from_import_usage():
+    p = Path(".")
+    print(p)
+
+
+def k1_lazy_from_import_usage_nofallthru():
+    p = Path(".")
+    print(p)
+    print("end")
+
+
+def l0_lazy_import_in_if():
+    if x:
+        data = json.loads('{"key": "value"}')
+        print(data)
+
+
+def l1_lazy_import_in_if_nofallthru():
+    if x:
+        data = json.loads('{"key": "value"}')
+        print(data)
+    print("end")

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "transformers" },
     { name = "transformers", extras = ["torch"] },
-    { name = "xdis", git = "https://github.com/jdw170000/python-xdis?rev=python-3.14" },
+    { name = "xdis", git = "https://github.com/quinntyx/python-xdis?rev=python-3.15-support" },
 ]
 
 [[package]]
@@ -2076,8 +2076,8 @@ wheels = [
 
 [[package]]
 name = "xdis"
-version = "6.3.0.dev0"
-source = { git = "https://github.com/jdw170000/python-xdis?rev=python-3.14#68a3b74c93d8a99aad463337c50e4e76222b59c2" }
+version = "6.3.1.dev0"
+source = { git = "https://github.com/quinntyx/python-xdis?rev=python-3.15-support#ac3c8a44e2dddd259114c85057e06749c3baa848" }
 dependencies = [
     { name = "click" },
     { name = "six" },

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "transformers" },
     { name = "transformers", extras = ["torch"] },
-    { name = "xdis", git = "https://github.com/quinntyx/python-xdis?rev=python-3.15-support" },
+    { name = "xdis", git = "https://github.com/rocky/python-xdis" },
 ]
 
 [[package]]
@@ -2077,7 +2077,7 @@ wheels = [
 [[package]]
 name = "xdis"
 version = "6.3.1.dev0"
-source = { git = "https://github.com/quinntyx/python-xdis?rev=python-3.15-support#ac3c8a44e2dddd259114c85057e06749c3baa848" }
+source = { git = "https://github.com/rocky/python-xdis#9467975d189fd6ac76c24c9a7eadc44c8ea79f9f" }
 dependencies = [
     { name = "click" },
     { name = "six" },


### PR DESCRIPTION
This PR implements Python 3.15 Support.

Changes:
- updated hardcoded UV table to allow support for Python 3.15
- `xdis` now supports 3.15
- Added new test cases for control flow reconstruction testing of new 3.15 features

That's it, this was a very simple update this time