### PR TITLE
Refactored Dev Scripts and QoL Improvements

### DIFF
--- a/dev_scripts/dataset_generation/DatasetDescription.py
+++ b/dev_scripts/dataset_generation/DatasetDescription.py
@@ -1,7 +1,24 @@
-from dataclasses import dataclass
+import json
+import logging
 import pathlib
+from dataclasses import dataclass
+from typing import List, Tuple, Union
 
-from typing import Tuple, List
+
+def get_dataset_description_from_arg_json(json_path: str, logger: Union[logging.Logger, None] = None) -> "DatasetDescription":
+    json_file_path = pathlib.Path(json_path)
+
+    if not json_file_path.exists():
+        raise FileNotFoundError(f"{json_file_path} does not exist")
+
+    if logger:
+        logger.info(f"Loading dataset description from {json_file_path}...")
+
+    with json_file_path.open() as json_file:
+        dataset_description_dict = json.load(json_file)
+
+    dataset_description_dict["data_requests"] = [DataRequest(**d) for d in dataset_description_dict["data_requests"]]
+    return DatasetDescription(**dataset_description_dict)
 
 
 @dataclass

--- a/dev_scripts/dataset_generation/compile_dataset.py
+++ b/dev_scripts/dataset_generation/compile_dataset.py
@@ -1,0 +1,66 @@
+# /// script
+# requires-python = ">= 3.12"
+# dependencies = [
+#   "pylingual",
+# ]
+# [tool.uv.sources]
+# pylingual = { path = "../../", editable = true }
+# ///
+
+import logging
+import multiprocessing
+import pathlib
+from typing import Optional, Tuple
+
+import click
+import tqdm
+
+from .DatasetDescription import get_dataset_description_from_arg_json
+from pylingual.utils.generate_bytecode import compile_version
+from pylingual.utils.get_logger import get_logger
+
+
+def compile_file(py_path: pathlib.Path, pyc_path: pathlib.Path, version: Tuple[int, int]) -> Optional[Exception]:
+    try:
+        compile_version(py_path, pyc_path, version)
+    except Exception as err:
+        return err
+    return None
+
+
+def star_compile_file(args):
+    return compile_file(*args)
+
+
+@click.command(help="Compile .py files to .pyc bytecode. Only compiles files missing their .pyc counterpart.")
+@click.argument("json_path", type=str)
+def main(json_path: str):
+    logger = get_logger("compile-dataset")
+    dataset_description = get_dataset_description_from_arg_json(json_path, logger)
+
+    if not dataset_description.code_dir.exists():
+        raise FileNotFoundError(f"{dataset_description.code_dir} does not exist. Run the generate stage first.")
+
+    compile_args = []
+    for py_path in dataset_description.code_dir.rglob("*.py"):
+        pyc_path = py_path.with_suffix(".pyc")
+        if not pyc_path.exists():
+            compile_args.append((py_path, pyc_path, dataset_description.version))
+
+    if not compile_args:
+        logger.info("All .py files already have corresponding .pyc files. Nothing to compile.")
+        return
+
+    logger.info(f"Compiling {len(compile_args)} files...")
+    num_fails = 0
+    with multiprocessing.Pool() as pool:
+        for error in tqdm.tqdm(pool.imap_unordered(star_compile_file, compile_args), total=len(compile_args)):
+            if error is not None:
+                num_fails += 1
+                logger.debug(error)
+
+    logger.info(f"Compilation complete. {num_fails} files failed to compile.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_scripts/dataset_generation/compile_dataset.py
+++ b/dev_scripts/dataset_generation/compile_dataset.py
@@ -9,6 +9,7 @@
 
 import logging
 import multiprocessing
+import os
 import pathlib
 from typing import Optional, Tuple
 
@@ -41,12 +42,27 @@ def main(json_path: str):
     if not dataset_description.code_dir.exists():
         raise FileNotFoundError(f"{dataset_description.code_dir} does not exist. Run the generate stage first.")
 
+    n_recent = os.cpu_count()
+    recent_pycs = []
     total_py = sum(dr.total_files for dr in dataset_description.data_requests)
     compile_args = []
     for py_path in tqdm.tqdm(dataset_description.code_dir.rglob("*.py"), desc="Scanning .py files", total=total_py):
         pyc_path = py_path.with_suffix(".pyc")
-        if not pyc_path.exists():
+        if pyc_path.exists():
+            mtime = pyc_path.stat().st_mtime
+            if len(recent_pycs) < n_recent:
+                recent_pycs.append((mtime, pyc_path))
+                if len(recent_pycs) == n_recent:
+                    recent_pycs.sort(key=lambda x: x[0])
+            elif mtime > recent_pycs[0][0]:
+                recent_pycs[0] = (mtime, pyc_path)
+                recent_pycs.sort(key=lambda x: x[0])
+        else:
             compile_args.append((py_path, pyc_path, dataset_description.version))
+
+    for _, pyc_path in recent_pycs:
+        pyc_path.unlink()
+        compile_args.append((pyc_path.with_suffix(".py"), pyc_path, dataset_description.version))
 
     if not compile_args:
         logger.info("All .py files already have corresponding .pyc files. Nothing to compile.")

--- a/dev_scripts/dataset_generation/compile_dataset.py
+++ b/dev_scripts/dataset_generation/compile_dataset.py
@@ -41,9 +41,9 @@ def main(json_path: str):
     if not dataset_description.code_dir.exists():
         raise FileNotFoundError(f"{dataset_description.code_dir} does not exist. Run the generate stage first.")
 
+    total_py = sum(dr.total_files for dr in dataset_description.data_requests)
     compile_args = []
-    all_py = list(tqdm.tqdm(dataset_description.code_dir.rglob("*.py"), desc="Scanning .py files"))
-    for py_path in tqdm.tqdm(all_py, desc="Checking .pyc"):
+    for py_path in tqdm.tqdm(dataset_description.code_dir.rglob("*.py"), desc="Scanning .py files", total=total_py):
         pyc_path = py_path.with_suffix(".pyc")
         if not pyc_path.exists():
             compile_args.append((py_path, pyc_path, dataset_description.version))

--- a/dev_scripts/dataset_generation/compile_dataset.py
+++ b/dev_scripts/dataset_generation/compile_dataset.py
@@ -68,13 +68,16 @@ def main(json_path: str):
         logger.info("All .py files already have corresponding .pyc files. Nothing to compile.")
         return
 
-    logger.info(f"Compiling {len(compile_args)} files...")
+    n_already = total_py - len(compile_args) + len(recent_pycs)
+    logger.info(f"Compiling {len(compile_args)} files ({n_already} already compiled)...")
     num_fails = 0
     with multiprocessing.Pool() as pool:
-        for error in tqdm.tqdm(pool.imap_unordered(star_compile_file, compile_args), total=len(compile_args)):
-            if error is not None:
-                num_fails += 1
-                logger.debug(error)
+        with tqdm.tqdm(total=total_py, initial=n_already, desc="Compiling") as pbar:
+            for error in pool.imap_unordered(star_compile_file, compile_args):
+                pbar.update(1)
+                if error is not None:
+                    num_fails += 1
+                    logger.debug(error)
 
     logger.info(f"Compilation complete. {num_fails} files failed to compile.")
 

--- a/dev_scripts/dataset_generation/compile_dataset.py
+++ b/dev_scripts/dataset_generation/compile_dataset.py
@@ -42,7 +42,8 @@ def main(json_path: str):
         raise FileNotFoundError(f"{dataset_description.code_dir} does not exist. Run the generate stage first.")
 
     compile_args = []
-    for py_path in dataset_description.code_dir.rglob("*.py"):
+    all_py = list(tqdm.tqdm(dataset_description.code_dir.rglob("*.py"), desc="Scanning .py files"))
+    for py_path in tqdm.tqdm(all_py, desc="Checking .pyc"):
         pyc_path = py_path.with_suffix(".pyc")
         if not pyc_path.exists():
             compile_args.append((py_path, pyc_path, dataset_description.version))

--- a/dev_scripts/dataset_generation/generate_csv.py
+++ b/dev_scripts/dataset_generation/generate_csv.py
@@ -1,0 +1,33 @@
+# /// script
+# requires-python = ">= 3.12"
+# dependencies = [
+#   "pylingual",
+# ]
+# [tool.uv.sources]
+# pylingual = { path = "../../", editable = true }
+# ///
+
+import click
+
+from .DatasetDescription import get_dataset_description_from_arg_json
+from .bytecode2csv import create_csv_dataset
+from pylingual.utils.get_logger import get_logger
+
+
+@click.command(help="Convert a code dataset to CSV format.")
+@click.argument("json_path", type=str)
+def main(json_path: str):
+    logger = get_logger("generate-csv")
+    dataset_description = get_dataset_description_from_arg_json(json_path, logger)
+
+    logger.info("Converting code dataset to csv...")
+    create_csv_dataset(
+        dataset_description.code_dir,
+        dataset_description.csv_dir,
+        dataset_description.data_requests,
+        logger,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_scripts/dataset_generation/generate_dataset.py
+++ b/dev_scripts/dataset_generation/generate_dataset.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = ">= 3.12"
+# dependencies = [
+#   "pylingual",
+# ]
+# [tool.uv.sources]
+# pylingual = { path = "../../", editable = true }
+# ///
+
+import click
+
+from .DatasetDescription import get_dataset_description_from_arg_json
+from .create_code_dataset import create_code_dataset
+from pylingual.utils.get_logger import get_logger
+
+
+@click.command(help="Generate the code dataset from a dataset description JSON.")
+@click.argument("json_path", type=str)
+def main(json_path: str):
+    logger = get_logger("generate-dataset")
+    dataset_description = get_dataset_description_from_arg_json(json_path, logger)
+
+    if dataset_description.code_dir.exists():
+        raise FileExistsError(f"{dataset_description.code_dir} already exists! The dataset name is probably already taken.")
+
+    logger.info("Creating code dataset...")
+    if not (dataset_description.data_requests and dataset_description.code_dir and dataset_description.version):
+        logger.error("Dataset description is missing required fields")
+        exit(1)
+
+    create_code_dataset(
+        dataset_description.data_requests,
+        dataset_description.code_dir,
+        dataset_description.version,
+        logger,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_scripts/dataset_generation/upload_dataset.py
+++ b/dev_scripts/dataset_generation/upload_dataset.py
@@ -16,12 +16,13 @@ from pylingual.utils.get_logger import get_logger
 
 @click.command(help="Upload a dataset to HuggingFace.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Upload as a public dataset instead of private.")
+def main(json_path: str, public: bool):
     logger = get_logger("upload-dataset")
     dataset_description = get_dataset_description_from_arg_json(json_path, logger)
 
-    logger.info(f"Uploading {dataset_description.name} to HuggingFace...")
-    upload_dataset_to_huggingface(dataset_description)
+    logger.info(f"Uploading {dataset_description.name} to HuggingFace ({'public' if public else 'private'})...")
+    upload_dataset_to_huggingface(dataset_description, public=public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/dataset_generation/upload_dataset.py
+++ b/dev_scripts/dataset_generation/upload_dataset.py
@@ -1,0 +1,28 @@
+# /// script
+# requires-python = ">= 3.12"
+# dependencies = [
+#   "pylingual",
+# ]
+# [tool.uv.sources]
+# pylingual = { path = "../../", editable = true }
+# ///
+
+import click
+
+from .DatasetDescription import get_dataset_description_from_arg_json
+from .upload_raw_dataset import upload_dataset_to_huggingface
+from pylingual.utils.get_logger import get_logger
+
+
+@click.command(help="Upload a dataset to HuggingFace.")
+@click.argument("json_path", type=str)
+def main(json_path: str):
+    logger = get_logger("upload-dataset")
+    dataset_description = get_dataset_description_from_arg_json(json_path, logger)
+
+    logger.info(f"Uploading {dataset_description.name} to HuggingFace...")
+    upload_dataset_to_huggingface(dataset_description)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_scripts/dataset_generation/upload_raw_dataset.py
+++ b/dev_scripts/dataset_generation/upload_raw_dataset.py
@@ -9,9 +9,9 @@ from .DatasetDescription import DatasetDescription
 LOCAL_DATASET = Dict[Literal["train", "test", "valid"], List[str]]
 
 
-def upload_single_dataset(data_files: LOCAL_DATASET, dataset_name: str, dataset_card: str):
+def upload_single_dataset(data_files: LOCAL_DATASET, dataset_name: str, dataset_card: str, public: bool = False):
     local_datasets = load_dataset("csv", data_files=data_files)
-    local_datasets.push_to_hub(dataset_name, private=True)
+    local_datasets.push_to_hub(dataset_name, private=not public)
 
     dataset_card_with_stats = dataset_card + f"\n\nDataset Statistics:\n\n```\n{local_datasets}\n```"
 
@@ -24,7 +24,7 @@ def upload_single_dataset(data_files: LOCAL_DATASET, dataset_name: str, dataset_
     )
 
 
-def upload_dataset_to_huggingface(dataset_description: DatasetDescription):
+def upload_dataset_to_huggingface(dataset_description: DatasetDescription, public: bool = False):
     formatted_data_requests = "\n".join(f"{str(req.source_path.resolve())}: (train: {req.num_train}, test: {req.num_test}, valid: {req.num_valid})" for req in dataset_description.data_requests)
     dataset_card = f"""
 # {dataset_description.name}
@@ -55,6 +55,6 @@ Python version: `{".".join(map(str, dataset_description.version))}`
 
     # upload datasets
     segmentation_dataset_name = f"{dataset_description.huggingface_user}/segmentation-{dataset_description.name}"
-    upload_single_dataset(segmentation_data_files, segmentation_dataset_name, dataset_card)
+    upload_single_dataset(segmentation_data_files, segmentation_dataset_name, dataset_card, public)
     statement_dataset_name = f"{dataset_description.huggingface_user}/statement-{dataset_description.name}"
-    upload_single_dataset(statement_data_files, statement_dataset_name, dataset_card)
+    upload_single_dataset(statement_data_files, statement_dataset_name, dataset_card, public)

--- a/dev_scripts/dataset_generation/validate_dataset.py
+++ b/dev_scripts/dataset_generation/validate_dataset.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = ">= 3.12"
+# dependencies = [
+#   "pylingual",
+# ]
+# [tool.uv.sources]
+# pylingual = { path = "../../", editable = true }
+# ///
+
+import click
+
+from .DatasetDescription import get_dataset_description_from_arg_json
+from pylingual.utils.get_logger import get_logger
+
+
+@click.command(help="Validate that a dataset's CSV files are complete.")
+@click.argument("json_path", type=str)
+def main(json_path: str):
+    logger = get_logger("validate-dataset")
+    dataset_description = get_dataset_description_from_arg_json(json_path, logger)
+
+    missing = []
+    for split in ("train", "test", "valid"):
+        for kind in ("segmentation", "statement"):
+            csv_dir = dataset_description.csv_dir / split / kind
+            csv_files = list(csv_dir.glob("*.csv")) if csv_dir.exists() else []
+            if not csv_files:
+                missing.append(f"{split}/{kind}")
+
+    if missing:
+        logger.error("Missing CSV files for the following split/type combinations:")
+        for entry in missing:
+            logger.error(f"  {entry}")
+        exit(1)
+
+    logger.info("All splits validated successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_scripts/prepare_dataset.py
+++ b/dev_scripts/prepare_dataset.py
@@ -45,27 +45,26 @@ def main(json_path: str):
     logger.debug(dataset_description)
 
     if dataset_description.code_dir.exists():
-        raise FileExistsError(f"{dataset_description.code_dir} already exists! The dataset name is probably already taken.")
+        logger.info(f"{dataset_description.code_dir} already exists, skipping dataset generation...")
+    else:
+        logger.info("Creating code dataset...")
+        if not (dataset_description.data_requests and dataset_description.code_dir and dataset_description.version):
+            logger.error("Dataset description is missing required fields")
+            exit(1)
+        create_code_dataset(
+            dataset_description.data_requests,
+            dataset_description.code_dir,
+            dataset_description.version,
+            logger,
+        )
 
-    logger.info("Creating code dataset...")
-    if not (dataset_description.data_requests and dataset_description.code_dir and dataset_description.version):
-        logger.error("Dataset description is missing required fields")
-        exit(1)
-    create_code_dataset(
-        dataset_description.data_requests,
-        dataset_description.code_dir,
-        dataset_description.version,
-        logger,
-    )
-
-    # create csv dataset
-    logger.info("Converting code dataset to csv...")
-    create_csv_dataset(
-        dataset_description.code_dir,
-        dataset_description.csv_dir,
-        dataset_description.data_requests,
-        logger,
-    )
+        logger.info("Converting code dataset to csv...")
+        create_csv_dataset(
+            dataset_description.code_dir,
+            dataset_description.csv_dir,
+            dataset_description.data_requests,
+            logger,
+        )
 
     logger.info(f"Uploading {dataset_description.name} to HuggingFace...")
     upload_dataset_to_huggingface(dataset_description)

--- a/dev_scripts/prepare_dataset.py
+++ b/dev_scripts/prepare_dataset.py
@@ -30,7 +30,8 @@ STAGES = ["generate", "compile", "csv", "validate", "upload"]
     type=click.Choice(STAGES),
     help="Stage(s) to run. May be specified multiple times. Defaults to all stages.",
 )
-def main(json_path: str, stage: tuple[str, ...]):
+@click.option("--public", is_flag=True, default=False, help="Upload as a public dataset instead of private.")
+def main(json_path: str, stage: tuple[str, ...], public: bool):
     logger = get_logger("prepare-dataset")
 
     stages_to_run = list(stage) if stage else STAGES
@@ -46,7 +47,7 @@ def main(json_path: str, stage: tuple[str, ...]):
         elif s == "validate":
             validate_dataset([json_path], standalone_mode=False)
         elif s == "upload":
-            upload_dataset([json_path], standalone_mode=False)
+            upload_dataset(["--public" if public else "", json_path], standalone_mode=False)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/prepare_dataset.py
+++ b/dev_scripts/prepare_dataset.py
@@ -47,7 +47,7 @@ def main(json_path: str, stage: tuple[str, ...], public: bool):
         elif s == "validate":
             validate_dataset([json_path], standalone_mode=False)
         elif s == "upload":
-            upload_dataset(["--public" if public else "", json_path], standalone_mode=False)
+            upload_dataset((["--public"] if public else []) + [json_path], standalone_mode=False)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/prepare_dataset.py
+++ b/dev_scripts/prepare_dataset.py
@@ -7,67 +7,43 @@
 # pylingual = { path = "../", editable = true }
 # ///
 
-import json
-import logging
-import pathlib
-from typing import Union
 import click
 
-from dataset_generation.bytecode2csv import create_csv_dataset
-from dataset_generation.create_code_dataset import create_code_dataset
-from dataset_generation.DatasetDescription import DataRequest, DatasetDescription
-from dataset_generation.upload_raw_dataset import upload_dataset_to_huggingface
+from dataset_generation.generate_dataset import main as generate_dataset
+from dataset_generation.generate_csv import main as generate_csv
+from dataset_generation.validate_dataset import main as validate_dataset
+from dataset_generation.upload_dataset import main as upload_dataset
 from pylingual.utils.get_logger import get_logger
 
-
-def get_dataset_description_from_arg_json(json_path: str, logger: Union[logging.Logger, None] = None) -> DatasetDescription:
-    json_file_path = pathlib.Path(json_path)
-
-    if not json_file_path.exists():
-        raise FileNotFoundError(f"{json_file_path} does not exist")
-
-    if logger:
-        logger.info(f"Loading dataset description from {json_file_path}...")
-
-    with json_file_path.open() as json_file:
-        dataset_description_dict = json.load(json_file)
-
-    dataset_description_dict["data_requests"] = [DataRequest(**d) for d in dataset_description_dict["data_requests"]]
-    return DatasetDescription(**dataset_description_dict)
+STAGES = ["generate", "csv", "validate", "upload"]
 
 
-@click.command(help="Samples, splits, processes, and uploads a given dataset described by JSON.")
+@click.command(
+    help="Run the dataset preparation pipeline. By default all stages run in order. "
+    "Use --stage to run specific stages (e.g. --stage csv --stage upload)."
+)
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option(
+    "--stage",
+    multiple=True,
+    type=click.Choice(STAGES),
+    help="Stage(s) to run. May be specified multiple times. Defaults to all stages.",
+)
+def main(json_path: str, stage: tuple[str, ...]):
     logger = get_logger("prepare-dataset")
 
-    dataset_description = get_dataset_description_from_arg_json(json_path, logger)
-    logger.debug(dataset_description)
+    stages_to_run = list(stage) if stage else STAGES
 
-    if dataset_description.code_dir.exists():
-        logger.info(f"{dataset_description.code_dir} already exists, skipping dataset generation...")
-    else:
-        logger.info("Creating code dataset...")
-        if not (dataset_description.data_requests and dataset_description.code_dir and dataset_description.version):
-            logger.error("Dataset description is missing required fields")
-            exit(1)
-        create_code_dataset(
-            dataset_description.data_requests,
-            dataset_description.code_dir,
-            dataset_description.version,
-            logger,
-        )
-
-        logger.info("Converting code dataset to csv...")
-        create_csv_dataset(
-            dataset_description.code_dir,
-            dataset_description.csv_dir,
-            dataset_description.data_requests,
-            logger,
-        )
-
-    logger.info(f"Uploading {dataset_description.name} to HuggingFace...")
-    upload_dataset_to_huggingface(dataset_description)
+    for s in stages_to_run:
+        logger.info(f"Running stage: {s}")
+        if s == "generate":
+            generate_dataset([json_path], standalone_mode=False)
+        elif s == "csv":
+            generate_csv([json_path], standalone_mode=False)
+        elif s == "validate":
+            validate_dataset([json_path], standalone_mode=False)
+        elif s == "upload":
+            upload_dataset([json_path], standalone_mode=False)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/prepare_dataset.py
+++ b/dev_scripts/prepare_dataset.py
@@ -10,12 +10,13 @@
 import click
 
 from dataset_generation.generate_dataset import main as generate_dataset
+from dataset_generation.compile_dataset import main as compile_dataset
 from dataset_generation.generate_csv import main as generate_csv
 from dataset_generation.validate_dataset import main as validate_dataset
 from dataset_generation.upload_dataset import main as upload_dataset
 from pylingual.utils.get_logger import get_logger
 
-STAGES = ["generate", "csv", "validate", "upload"]
+STAGES = ["generate", "compile", "csv", "validate", "upload"]
 
 
 @click.command(
@@ -38,6 +39,8 @@ def main(json_path: str, stage: tuple[str, ...]):
         logger.info(f"Running stage: {s}")
         if s == "generate":
             generate_dataset([json_path], standalone_mode=False)
+        elif s == "compile":
+            compile_dataset([json_path], standalone_mode=False)
         elif s == "csv":
             generate_csv([json_path], standalone_mode=False)
         elif s == "validate":

--- a/dev_scripts/segmentation/tokenize_seg.py
+++ b/dev_scripts/segmentation/tokenize_seg.py
@@ -127,7 +127,7 @@ def tokenize_and_align_labels(tokenizer: PreTrainedTokenizerFast, max_length: in
     return tokenized_inputs
 
 
-def tokenize_segmentation_dataset(config: SegmentationConfiguration):
+def tokenize_segmentation_dataset(config: SegmentationConfiguration, public: bool = False):
     raw_dataset = load_dataset(config.dataset_repo_name, token=True, cache_dir=str(config.dataset_dir))
 
     tokenizer = load_tokenizer(config.tokenizer_repo_name, config.cache_dir)
@@ -145,16 +145,17 @@ def tokenize_segmentation_dataset(config: SegmentationConfiguration):
 
     tokenized_datasets.push_to_hub(
         config.tokenized_dataset_repo_name,
-        private=True,
+        private=not public,
     )
 
 
 @click.command(help="Script to tokenize the segmentation dataset given a segmentation json.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(json_path: str, public: bool):
     json_file_path = pathlib.Path(json_path)
     segmentation_config = parse_segmentation_config_json(json_file_path)
-    tokenize_segmentation_dataset(segmentation_config)
+    tokenize_segmentation_dataset(segmentation_config, public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/segmentation/train_mlm.py
+++ b/dev_scripts/segmentation/train_mlm.py
@@ -136,7 +136,7 @@ def initialize_untrained_mlm(
     return model
 
 
-def train_mlm(config: SegmentationConfiguration):
+def train_mlm(config: SegmentationConfiguration, public: bool = False):
     if repo_exists(config.base_repo_name):
         logging.error(f"{config.base_repo_name} has already exists")
         exit(1)
@@ -152,7 +152,7 @@ def train_mlm(config: SegmentationConfiguration):
         prediction_loss_only=True,
         push_to_hub=True,
         hub_model_id=config.mlm_repo_name,
-        hub_private_repo=True,
+        hub_private_repo=not public,
         ddp_backend="nccl",
         ddp_find_unused_parameters=using_pretrained_model,  # only look for unused parameters in pretrained models
         remove_unused_columns=False,
@@ -194,10 +194,11 @@ def train_mlm(config: SegmentationConfiguration):
 
 @click.command(help="Training script for the masked language model pretraining for the segmentation model given a segmentation json.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(json_path: str, public: bool):
     json_file_path = pathlib.Path(json_path)
     segmentation_config = parse_segmentation_config_json(json_file_path)
-    train_mlm(segmentation_config)
+    train_mlm(segmentation_config, public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/segmentation/train_seg.py
+++ b/dev_scripts/segmentation/train_seg.py
@@ -76,7 +76,7 @@ def load_tokenized_train_and_valid_dataset(dataset_repo_name: str, cache_dir: pa
     return tokenized_train_dataset, tokenized_validation_dataset
 
 
-def train_segmentation_model(config: SegmentationConfiguration):
+def train_segmentation_model(config: SegmentationConfiguration, public: bool = False):
     if repo_exists(config.base_repo_name):
         logging.error(f"{config.base_repo_name} has already exists")
         exit(1)
@@ -95,7 +95,7 @@ def train_segmentation_model(config: SegmentationConfiguration):
         fp16=True,
         push_to_hub=True,
         hub_model_id=config.segmenter_repo_name,
-        hub_private_repo=True,
+        hub_private_repo=not public,
         ddp_backend="nccl",
         ddp_find_unused_parameters=True,
         save_total_limit=5,
@@ -145,10 +145,11 @@ def train_segmentation_model(config: SegmentationConfiguration):
 
 @click.command(help="Training script for the segmentation model given a segmentation json.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(json_path: str, public: bool):
     json_file_path = pathlib.Path(json_path)
     segmentation_config = parse_segmentation_config_json(json_file_path)
-    train_segmentation_model(segmentation_config)
+    train_segmentation_model(segmentation_config, public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/segmentation/train_tokenizer.py
+++ b/dev_scripts/segmentation/train_tokenizer.py
@@ -43,14 +43,13 @@ def save_and_upload_tokenizer(
     tokenizer_json_path: pathlib.Path,
     tokenizer_repo_name: str,
     dataset_name: str,
+    public: bool = False,
 ):
-    # save the tokenizer locally
     tokenizer_json_path.parent.mkdir(parents=True, exist_ok=True)
     tokenizer.save(str(tokenizer_json_path.resolve()))
 
-    # upload tokenizer to huggingface
     api = HfApi()
-    create_repo(tokenizer_repo_name, exist_ok=True, private=True)
+    create_repo(tokenizer_repo_name, exist_ok=True, private=not public)
     api.upload_file(
         path_in_repo="tokenizer.json",
         path_or_fileobj=str(tokenizer_json_path.resolve()),
@@ -59,7 +58,7 @@ def save_and_upload_tokenizer(
     )
 
 
-def train_tokenizer(config: SegmentationConfiguration):
+def train_tokenizer(config: SegmentationConfiguration, public: bool = False):
     if repo_exists(config.base_repo_name):
         logging.error(f"{config.base_repo_name} has already exists")
         exit(1)
@@ -81,15 +80,17 @@ def train_tokenizer(config: SegmentationConfiguration):
         config.tokenizer_json_path,
         config.tokenizer_repo_name,
         config.dataset_repo_name,
+        public,
     )
 
 
 @click.command(help="Training script for the bytecode tokenizer for the segmentation model given a segmentation json.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(json_path: str, public: bool):
     json_file_path = pathlib.Path(json_path)
     segmentation_config = parse_segmentation_config_json(json_file_path)
-    train_tokenizer(segmentation_config)
+    train_tokenizer(segmentation_config, public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/statement/tokenize_seq2seq.py
+++ b/dev_scripts/statement/tokenize_seq2seq.py
@@ -20,7 +20,7 @@ def preprocess_function(tokenizer: RobertaTokenizer, max_token_length: int, inpu
     return tokenizer(text=inputs, text_target=targets, max_length=max_token_length, truncation=True)
 
 
-def tokenize_seq2seq_dataset(config: StatementConfiguration):
+def tokenize_seq2seq_dataset(config: StatementConfiguration, public: bool = False):
     # ref: https://huggingface.co/Salesforce/codet5-base
     tokenizer = RobertaTokenizer.from_pretrained(config.tokenizer_repo_name)
     raw_datasets = load_dataset(config.dataset_repo_name, token=True)
@@ -36,15 +36,16 @@ def tokenize_seq2seq_dataset(config: StatementConfiguration):
         desc="Tokenizing datasets",
     )
 
-    tokenized_datasets.push_to_hub(config.tokenized_dataset_repo_name, private=True)
+    tokenized_datasets.push_to_hub(config.tokenized_dataset_repo_name, private=not public)
 
 
 @click.command(help="Tokenization script for Statement Translation model given a statement json.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(json_path: str, public: bool):
     json_file_path = pathlib.Path(json_path)
     statement_config = parse_statement_config_json(json_file_path)
-    tokenize_seq2seq_dataset(statement_config)
+    tokenize_seq2seq_dataset(statement_config, public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/statement/train_seq2seq.py
+++ b/dev_scripts/statement/train_seq2seq.py
@@ -25,7 +25,7 @@ def load_tokenized_train_dataset(dataset_repo_name: str, dataset_percentage: int
     return tokenized_train_dataset
 
 
-def train_statement_model(config: StatementConfiguration):
+def train_statement_model(config: StatementConfiguration, public: bool = False):
     # load model, Salesforce/codet5-base is a pretrained model solving the code generation task.
     tokenizer = RobertaTokenizer.from_pretrained(config.tokenizer_repo_name)
     model = T5ForConditionalGeneration.from_pretrained(config.pretrained_seq2seq_repo_name)
@@ -52,7 +52,7 @@ def train_statement_model(config: StatementConfiguration):
         predict_with_generate=True,
         push_to_hub=True,
         hub_model_id=model_repo_name,
-        hub_private_repo=True,
+        hub_private_repo=not public,
         ddp_backend="nccl",
         ddp_find_unused_parameters=False,
     )
@@ -83,10 +83,11 @@ def train_statement_model(config: StatementConfiguration):
 
 @click.command(help="Training script for the statement translation model given a statement json.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(json_path: str, public: bool):
     json_file_path = pathlib.Path(json_path)
     statement_config = parse_statement_config_json(json_file_path)
-    train_statement_model(statement_config)
+    train_statement_model(statement_config, public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/statement/train_tokenizer_auto.py
+++ b/dev_scripts/statement/train_tokenizer_auto.py
@@ -20,13 +20,12 @@ def save_and_upload_tokenizer(
     tokenizer_json_path: pathlib.Path,
     tokenizer_repo_name: str,
     dataset_name: str,
+    public: bool = False,
 ):
-    # Save the tokenizer locally
     tokenizer.save_pretrained(str(tokenizer_json_path.parent.resolve()))
 
-    # Upload files to Hugging Face Hub
     api = HfApi()
-    api.create_repo(tokenizer_repo_name, exist_ok=True, private=True)
+    api.create_repo(tokenizer_repo_name, exist_ok=True, private=not public)
     api.upload_file(
         path_in_repo="tokenizer_config.json",
         path_or_fileobj=str(tokenizer_json_path.parent / "tokenizer_config.json"),
@@ -59,7 +58,7 @@ def save_and_upload_tokenizer(
     )
 
 
-def train_tokenizer(config: StatementConfiguration, tokenizer_json_path: pathlib.Path):
+def train_tokenizer(config: StatementConfiguration, tokenizer_json_path: pathlib.Path, public: bool = False):
     if repo_exists(config.base_repo_name):
         logging.error(f"{config.base_repo_name} has already exists")
         exit(1)
@@ -78,15 +77,17 @@ def train_tokenizer(config: StatementConfiguration, tokenizer_json_path: pathlib
         tokenizer_json_path,
         config.tokenizer_repo_name,
         config.dataset_repo_name,
+        public,
     )
 
 
 @click.command(help="Training script for the bytecode tokenizer for the statement model given a statement json.")
 @click.argument("json_path", type=str)
-def main(json_path: str):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(json_path: str, public: bool):
     json_file_path = pathlib.Path(json_path)
     statement_config = parse_statement_config_json(json_file_path)
-    train_tokenizer(statement_config, json_file_path)
+    train_tokenizer(statement_config, json_file_path, public)
 
 
 if __name__ == "__main__":

--- a/dev_scripts/train_models.py
+++ b/dev_scripts/train_models.py
@@ -16,12 +16,16 @@ import click
 from pylingual.utils.get_logger import get_logger
 
 
-def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.Logger, nnodes: int = 1, nproc_per_node: int = 1, rdzv_port: int = 29400):
+def _public_flag(public: bool) -> list[str]:
+    return ["--public"] if public else []
+
+
+def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.Logger, nnodes: int = 1, nproc_per_node: int = 1, rdzv_port: int = 29400, public: bool = False):
     segmentation_root = pathlib.Path(__file__).parent / "segmentation"
 
     # train tokenizer
     logger.info("training tokenizer...")
-    subprocess.run(["uv", "run", segmentation_root / "train_tokenizer.py", segmentation_config_path])
+    subprocess.run(["uv", "run", segmentation_root / "train_tokenizer.py", *_public_flag(public), segmentation_config_path])
 
     # train mlm (single gpu to avoid conflicts with local tokenized data)
     logger.info("training masked language model...")
@@ -35,6 +39,7 @@ def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.L
             "--rdzv-backend=c10d",
             f"--rdzv-endpoint=localhost:{rdzv_port}",
             segmentation_root / "train_mlm.py",
+            *_public_flag(public),
             segmentation_config_path,
         ],
         env=dict(os.environ, NCCL_P2P_DISABLE="1"),
@@ -42,7 +47,7 @@ def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.L
 
     # tokenize dataset
     logger.info("tokenizing segmentation dataset...")
-    subprocess.run(["uv", "run", segmentation_root / "tokenize_seg.py", segmentation_config_path])
+    subprocess.run(["uv", "run", segmentation_root / "tokenize_seg.py", *_public_flag(public), segmentation_config_path])
 
     # train segmentation model (4 gpus)
     logger.info("training segmentation model...")
@@ -56,21 +61,22 @@ def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.L
             "--rdzv-backend=c10d",
             f"--rdzv-endpoint=localhost:{rdzv_port}",
             segmentation_root / "train_seg.py",
+            *_public_flag(public),
             segmentation_config_path,
         ],
         env=dict(os.environ, NCCL_P2P_DISABLE="1"),
     )
 
 
-def train_statement(statement_config_path: pathlib.Path, logger: logging.Logger, nnodes: int = 1, nproc_per_node: int = 1, rdzv_port: int = 29400):
+def train_statement(statement_config_path: pathlib.Path, logger: logging.Logger, nnodes: int = 1, nproc_per_node: int = 1, rdzv_port: int = 29400, public: bool = False):
     statement_root = pathlib.Path(__file__).parent / "statement"
 
     # manual tokenizer
-    subprocess.run(["uv", "run", statement_root / "train_tokenizer_auto.py", statement_config_path])
+    subprocess.run(["uv", "run", statement_root / "train_tokenizer_auto.py", *_public_flag(public), statement_config_path])
 
     # tokenize statement dataset with salesforce tokenizer
     logger.info("tokenizing statement dataset...")
-    subprocess.run(["uv", "run", statement_root / "tokenize_seq2seq.py", statement_config_path])
+    subprocess.run(["uv", "run", statement_root / "tokenize_seq2seq.py", *_public_flag(public), statement_config_path])
 
     # train statement model (4 gpus)
     logger.info("training statement model...")
@@ -84,6 +90,7 @@ def train_statement(statement_config_path: pathlib.Path, logger: logging.Logger,
             "--rdzv-backend=c10d",
             f"--rdzv-endpoint=localhost:{rdzv_port}",
             statement_root / "train_seq2seq.py",
+            *_public_flag(public),
             statement_config_path,
         ],
         env=dict(os.environ, NCCL_P2P_DISABLE="1"),
@@ -96,7 +103,8 @@ def train_statement(statement_config_path: pathlib.Path, logger: logging.Logger,
 @click.option("--nnodes", type=int, default=1, help="Torchrun nnodes arg")
 @click.option("--nproc_per_node", type=int, default=1, help="Torchrun nproc_per_node arg")
 @click.option("--rdzv_port", "-p", type=int, default=29400, help="Port to use for torchrun rendezvous endpoint")
-def main(segmentation: str, statement: str, nnodes: int, nproc_per_node: int, rdzv_port: int):
+@click.option("--public", is_flag=True, default=False, help="Make uploaded HuggingFace repos public (default: private)")
+def main(segmentation: str, statement: str, nnodes: int, nproc_per_node: int, rdzv_port: int, public: bool):
     logger = get_logger("train-models")
 
     ### LOAD JSON
@@ -112,7 +120,7 @@ def main(segmentation: str, statement: str, nnodes: int, nproc_per_node: int, rd
     ### TRAIN SEGMENTATION
     if segmentation_config_path is not None:
         logger.info("Segmentation model training starting...")
-        train_segmentation(segmentation_config_path, logger, nnodes, nproc_per_node, rdzv_port)
+        train_segmentation(segmentation_config_path, logger, nnodes, nproc_per_node, rdzv_port, public)
         logger.info("Segmentation model training complete!")
     else:
         logger.warning("Segmentation model configuration json path not provided in --segmentation; skipping segmentation model training...")
@@ -120,7 +128,7 @@ def main(segmentation: str, statement: str, nnodes: int, nproc_per_node: int, rd
     ### TRAIN STATEMENT
     if statement_config_path is not None:
         logger.info("Statement model training starting...")
-        train_statement(statement_config_path, logger, nnodes, nproc_per_node, rdzv_port)
+        train_statement(statement_config_path, logger, nnodes, nproc_per_node, rdzv_port, public)
         logger.info("Statement model training complete!")
     else:
         logger.warning("Statement model configuration json path not provided in --statement; skipping statement model training...")

--- a/pylingual/utils/get_logger.py
+++ b/pylingual/utils/get_logger.py
@@ -4,26 +4,23 @@ import os
 
 
 def get_logger(name: str) -> logging.Logger:
-    # Create a logger
-    logger = logging.getLogger()
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
     logger.setLevel(logging.DEBUG)
-    # Create a file handler
     current_datetime = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    if not os.path.exists("logs"):  # create a logging directory if not exists
+    if not os.path.exists("logs"):
         os.makedirs("logs")
     file_handler = logging.FileHandler(f"logs/{name}_{current_datetime}.log", mode="w")
     file_handler.setLevel(logging.DEBUG)
 
-    # Create a console handler
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.INFO)
 
-    # Create a formatter and add it to the handlers
     formatter = logging.Formatter("%(asctime)s- %(levelname)s - %(message)s")
     file_handler.setFormatter(formatter)
     console_handler.setFormatter(formatter)
 
-    # Add the handlers to the logger
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
 


### PR DESCRIPTION
This PR refactors multiple `dev_scripts`, including both the dataset generation and training steps. 

## Motivation
- Running large preparation stages are hard to debug if any part of the pipeline breaks
- If interrupted, many of the original pipeline implementations are unresumable
- HF private storage has recently been reduced
- Sometimes, scripts would take a long time with no visible progress indication

## Implementation
- Refactored prepare_dataset.py to use multiple explicit stages, which can each be individually run, allowing for ease of debugging, via `--stage` flag
- Dataset preparation is now interruptible/resumable, and will defensively discard `os.cpu_count()` recent compilation artifacts to prevent corruption regardless of how dataset preparation was interrupted
- Added `--public` flag to all relevant scripts, allowing you to instruct any part of the pipeline to upload artifacts to HF public storage as needed
- TQDM progress bars have been added to more places, as many as I thought needed it

## Notes
The CLI changes to dev_scripts were made all without changing existing CLI interface behavior. These features are implemented as a strict extension of existing behavior, so nothing should break as a result of these changes. 