### PR TITLE
Stop running beam search by accident in statement translation (20-35x faster)

### DIFF
--- a/pylingual/models.py
+++ b/pylingual/models.py
@@ -29,6 +29,9 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# real statements decode to a few dozen tokens; anything near this length is a stuck greedy decode
+RUNAWAY_TOKENS = 100
+
 
 # translator with caching
 class CacheTranslator:
@@ -54,14 +57,32 @@ class CacheTranslator:
         batch_size: int = 32,
         **kwargs,
     ) -> list[str]:
+        # every batch pads to its longest member, so group similar lengths together and undo the order after
+        items = translation_requests.x if isinstance(translation_requests, TrackedDataset) else list(translation_requests)
+        tokenizer = self.translator.tokenizer
+        order = sorted(range(len(items)), key=lambda i: len(tokenizer(items[i])["input_ids"]))
+        sorted_items = [items[i] for i in order]
+        if isinstance(translation_requests, TrackedDataset):
+            sorted_items = TrackedDataset(translation_requests.name, sorted_items, translation_requests.check_timeout)
+
         # return_tensors=True prevents standard postprocessing which skips special tokens
-        translation_result = self.translator(translation_requests, return_tensors=True, batch_size=batch_size, **kwargs)
-        decoded_results = []
-        for result in flatten(translation_result):
+        translation_result = self.translator(sorted_items, return_tensors=True, batch_size=batch_size, **kwargs)
+        decoded_results = [None] * len(items)
+        runaway = []
+        for i, result in zip(order, flatten(translation_result)):
             # explicitly filter out the special tokens we want to skip: <pad>, <s>, </s>, <unk>, <mask>
             filtered_tokens = [tok for tok in result["translation_token_ids"].tolist() if tok not in [0, 1, 2, 3, 4]]
+            if len(filtered_tokens) >= RUNAWAY_TOKENS and kwargs.get("num_beams", 1) == 1:
+                runaway.append(i)
             # decode the remaining tokens
-            decoded_results.append(self.translator.tokenizer.decode(filtered_tokens, skip_special_tokens=False))
+            decoded_results[i] = self.translator.tokenizer.decode(filtered_tokens, skip_special_tokens=False)
+
+        # greedy decoding can fall into a repetition loop on deeply nested expressions; beam search recovers those
+        if runaway:
+            logger.info(f"Retranslating {len(runaway)} runaway statement(s) with beam search")
+            retried = self._translate_and_decode([items[i] for i in runaway], batch_size=batch_size, **{**kwargs, "num_beams": 4})
+            for i, text in zip(runaway, retried):
+                decoded_results[i] = text
 
         return decoded_results
 
@@ -137,11 +158,10 @@ def load_models(
     if torch.cuda.is_available():
         logger.info("Using CUDA GPU for models")
         device = torch.device("cuda:0")
-    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        logger.info("Using MPS (Metal Performance Shaders) GPU for models")
-        device = torch.device("mps")
     else:
-        logger.warning("Using CPU for models")
+        # MPS recompiles its Metal graph on every T5 decode step, which makes it far slower than
+        # CPU for this workload, so it is not used even when available.
+        logger.info("Using CPU for models")
         device = torch.device("cpu")
     segmenter = transformers.pipeline(
         "token-classification",
@@ -161,6 +181,8 @@ def load_models(
         max_length=512,
         truncation=False,
         device=device,
+        # the pipeline class defaults to num_beams=4, overriding the num_beams=1 the model ships with
+        num_beams=1,
     )
 
     return segmenter, CacheTranslator(translator)

--- a/pylingual/utils/generate_bytecode.py
+++ b/pylingual/utils/generate_bytecode.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import functools
 import subprocess
 import sys
 import py_compile
@@ -32,10 +33,26 @@ def _compile_native(py_file: str, out_file: str):
     return
 
 
+@functools.lru_cache(maxsize=None)
+def _uv_python(version: PythonVersion) -> str | None:
+    """Resolve the interpreter uvx would use, so repeated compiles can skip uvx's per-call resolution."""
+    try:
+        found = subprocess.run(["uv", "python", "find", version.as_str()], shell=False, capture_output=True, text=True)
+        path = found.stdout.strip()
+        if found.returncode != 0 or not path:
+            return None
+        # confirm the version before trusting it, otherwise a bad resolve turns every compile into a CompileError
+        check = subprocess.run([path, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"], shell=False, capture_output=True, text=True)
+        return path if check.stdout.strip() == version.as_str() else None
+    except Exception:
+        return None
+
+
 def _compile_uv(py_file: str, out_file: str, version: PythonVersion):
     compile_cmd = f"import py_compile, sys; assert sys.version_info[:2] == {version.as_tuple()!r}; py_compile.compile({py_file!r}, cfile={out_file!r})"
 
-    cmd = ["uvx", "--no-config", "--python", version.as_str(), "python", "-c", compile_cmd]
+    python = _uv_python(version)
+    cmd = [python, "-c", compile_cmd] if python else ["uvx", "--no-config", "--python", version.as_str(), "python", "-c", compile_cmd]
 
     output = subprocess.run(cmd, shell=False, capture_output=True, text=True, env={**os.environ, "PYTHONWARNINGS": "ignore"})
 


### PR DESCRIPTION
`Text2TextGenerationPipeline` carries `num_beams=4` in its class-level default generation config, and that overrides the `num_beams=1` the statement model declares in its own `generation_config`. `num_beams` has never appeared anywhere in this repository, so every statement translation has been running 4-way beam search that nobody selected. Restoring the model's own setting is most of the speedup here, and it is not a speed-for-quality trade: the model was published expecting greedy decoding.

Two smaller costs sit on the same paths:

- **Length-sorted translation batches.** Each batch pads to its longest member, and request lengths vary widely (median 57 tokens, max 450). Sorting by token length before batching cuts the translation stage by 1.57x with byte-identical output.
- **One interpreter resolution instead of `uvx` per compile.** `check_reconstruction` shells out for every equivalence check — 39 calls on a 5-file run — and `uvx` re-resolves its environment each time: 0.137s per call against 0.018s for the resolved interpreter, producing identical bytecode. This was 21% of total runtime. It falls back to `uvx` when resolution fails or returns the wrong version.

Greedy decoding can fall into a repetition loop on deeply nested expressions — `statistics._normal_dist_inv_cdf` decodes to a run of open parens instead of a polynomial. These generations are self-identifying: they reach 402-510 tokens where correct statements top out at 89. Any statement whose greedy output hits 100 tokens is retranslated with beam search. The threshold produced no false positives across 454 requests, fires 1-3 times per module, and costs about 9% of runtime.

This also drops MPS, which recompiles its Metal graph on every T5 decode step. That made it far slower than CPU (1774s against 123s on an 82-line file) and it was selected by default whenever `torch.backends.mps.is_available()`.

## Measurements

Complete runs on CPU against the current default, no truncation:

| corpus | before | after | speedup |
| --- | --- | --- | --- |
| `test/`, 5 files | 713.7s | 20.4s | 34.9x |
| 12 stdlib modules | 3671.7s | 181.0s | 20.3x |

Per-module speedups range from 6.9x (`statistics`) to 45.9x (`fractions`). The stdlib corpus is `textwrap`, `queue`, `bisect`, `random`, `statistics`, `fractions`, `colorsys`, `getpass`, `shlex`, `csv`, `difflib`, `gettext`, compiled to 3.9.

## Correctness

Code object success rate is unchanged on all 17 files and improves on one (`test/Generator.py`, 0.875 → 1.000). 9 of the 12 stdlib outputs are byte-identical to the previous ones; the 3 that differ do so only in equivalent forms — bare `return` against `return None`, and set literal element order.

The two performance fixes were checked separately for output identity: the length-sorted batching produces the same hash across 10 batch-size and ordering configurations, and the resolved interpreter produces bytecode identical to `uvx`.

## Note on the previous version of this PR

This branch previously added an optional Core ML/Neural Engine backend and reported it as ~6.6x faster than CPU. That comparison was against the beam search baseline fixed here, so it mostly measured greedy decoding against beam search rather than one backend against another. Measured against the corrected CPU path, the Core ML backend is about 1.6x *slower* on this workload: the decoder needs one `predict()` per token and each call has a floor of roughly 4ms that a KV cache, smaller fixed shapes, and batching all failed to remove. The Core ML code has been dropped from this PR for that reason. The MPS finding was independent of it and is kept.
