### PR TITLE
Robust CSV dataset generation: retries, timeouts, resume, and stall reporting

### DIFF
--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -13,7 +13,6 @@ import logging
 import multiprocessing
 import pathlib
 import re
-import signal
 import time
 from typing import Callable, Tuple
 
@@ -178,11 +177,21 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             yield (py_path, pyc_path)
 
     num_fails = 0
-    with multiprocessing.Pool(maxtasksperchild=1000) as pool:
-        for result in pool.imap_unordered(bytecode2csv_exception_wrapper, bytecode2csv_args()):
+    with multiprocessing.Pool(maxtasksperchild=100) as pool:
+        iterator = pool.imap_unordered(bytecode2csv_exception_wrapper, bytecode2csv_args())
+        while True:
+            try:
+                result = iterator.next(timeout=300)
+            except StopIteration:
+                break
+            except multiprocessing.TimeoutError:
+                num_fails += 1
+                if logger:
+                    logger.warning(f"Task timed out after 300s (num_fails={num_fails})")
+                continue
             if isinstance(result, Exception):
                 num_fails += 1
-                logger.debug(f"DIR: {dir}\nERR: {result}\nTYPE ERR: {type(result)}\n")
+                logger.debug(f"ERR: {result}\nTYPE ERR: {type(result)}\n")
                 continue
 
             (segmentation_rows, statement_rows) = result
@@ -198,19 +207,10 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
     logger.info(f"NUMBER OF FAILS !!! {num_fails}")
 
 
-def timeout_handler(signum, frame):
-    raise TimeoutError()
-
-
 def bytecode2csv_exception_wrapper(paths=Tuple[pathlib.Path, pathlib.Path]) -> Tuple[list, list] | Exception:
-    signal.signal(signal.SIGALRM, timeout_handler)
     try:
-        signal.alarm(30)  # set 30 second timeout
-        results = bytecode2csv(*paths)
-        signal.alarm(0)  # success; disable timer
-        return results
+        return bytecode2csv(*paths)
     except Exception as error:
-        signal.alarm(0)  # disable timer in case another exception triggered the fail
         return Exception(f"{type(error)}: {error} in file {paths}")
 
 

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -69,11 +69,15 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
         out_dir.mkdir(exist_ok=True)
 
         for csv_idx in itertools.count():
-            new_path = out_dir.joinpath(f"{file_prefix}_{csv_idx}.csv")
-            new_path.touch()
+            @retry_on_nas_error()
+            def open_csv():
+                new_path = out_dir.joinpath(f"{file_prefix}_{csv_idx}.csv")
+                new_path.touch()
+                return new_path.open(mode="w")
+            csv_file = open_csv()
             if logger:
-                logger.info(f"Creating new csv {new_path.resolve()}...")
-            with new_path.open(mode="w") as csv_file:
+                logger.info(f"Creating new csv {csv_file.name}...")
+            with csv_file:
                 writer = csv.writer(csv_file)
                 writer.writerow(csv_header)
                 for writer in itertools.repeat(writer, max_csv_rows):

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -87,17 +87,41 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
     statement_writer = csv_writer("statement", CSV_STMT_HEADER)
 
     # create dirs
-    code_dirs = (child for child in source_path.iterdir() if child.is_dir())
+    def safe_code_dirs():
+        try:
+            it = source_path.iterdir()
+        except OSError:
+            return
+        while True:
+            try:
+                child = next(it)
+            except OSError:
+                continue
+            except StopIteration:
+                return
+            try:
+                if child.is_dir():
+                    yield child
+            except OSError:
+                continue
+    code_dirs = safe_code_dirs()
 
     def bytecode2csv_args():
-        for dir in code_dirs:
-            py_path = next(dir.glob("*.py"), None)
-            pyc_path = next(dir.glob("*.pyc"), None)
-            if None in (py_path, pyc_path):
-                logging.debug(f"PY or PYC file not found in {dir}")
+        while True:
+            try:
+                try:
+                    dir = next(code_dirs)
+                except OSError:
+                    continue
+                except StopIteration:
+                    return
+                py_path = next(dir.glob("*.py"), None)
+                pyc_path = next(dir.glob("*.pyc"), None)
+            except OSError:
                 continue
-            else:
-                yield (py_path, pyc_path)
+            if None in (py_path, pyc_path):
+                continue
+            yield (py_path, pyc_path)
 
     num_fails = 0
     with multiprocessing.Pool() as pool:

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -14,6 +14,7 @@ import multiprocessing
 import pathlib
 import re
 import signal
+import time
 from typing import Callable, Tuple
 
 import tqdm
@@ -28,6 +29,21 @@ bytecode_separator = " <SEP> "
 source_seperator = " <SEP> "
 CSV_SGMT_HEADER = ["source", "bytecode", "boundary", "file"]
 CSV_STMT_HEADER = ["source", "bytecode", "file"]
+
+
+def retry_on_nas_error(max_retries=3, base_delay=1):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            for attempt in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except OSError as e:
+                    if attempt < max_retries - 1:
+                        time.sleep(base_delay * (2 ** attempt))
+                    else:
+                        raise
+        return wrapper
+    return decorator
 
 
 def create_csv_dataset(code_dataset_path: pathlib.Path, csv_dataset_path: pathlib.Path, data_requests: list[DataRequest], logger: logging.Logger = None):
@@ -116,6 +132,7 @@ def bytecode2csv_exception_wrapper(paths=Tuple[pathlib.Path, pathlib.Path]) -> T
         return Exception(f"{type(error)}: {error} in file {paths}")
 
 
+@retry_on_nas_error()
 def bytecode2csv(py_path: pathlib.Path, pyc_path: pathlib.Path) -> tuple[list, list]:
     """Creates segmentation and statement csv rows for given bytecode and source file"""
     segmentation_rows = []

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -70,12 +70,40 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             logger.warning(f"Unable to access CSV output directory {csv_output_path}: {error}; skipping split")
         return
 
+    # Resume: load checkpoint of already-processed source files
+    checkpoint_file = csv_output_path / ".checkpoint"
+    processed_paths: set[str] = set()
+    if checkpoint_file.exists():
+        try:
+            for line in checkpoint_file.read_text().splitlines():
+                p = line.strip()
+                if p:
+                    processed_paths.add(p)
+            if logger and processed_paths:
+                logger.info(f"Resuming: {len(processed_paths)} source files already processed")
+        except OSError:
+            pass
+
+    def get_start_idx(prefix: str) -> int:
+        """Return the next CSV file index after the highest existing one."""
+        out_dir = csv_output_path.joinpath(prefix)
+        try:
+            files = list(out_dir.glob(f"{prefix}_*.csv"))
+        except OSError:
+            return 0
+        if not files:
+            return 0
+        try:
+            return max(int(f.stem.split("_")[-1]) for f in files) + 1
+        except (ValueError, IndexError):
+            return 0
+
     ##### csv write wrappers to preserve csv row limit
 
-    def csv_writer(file_prefix: str, csv_header: list) -> Callable:
+    def csv_writer(file_prefix: str, csv_header: list, start_idx: int = 0) -> Callable:
         out_dir = csv_output_path.joinpath(file_prefix)
 
-        for csv_idx in itertools.count():
+        for csv_idx in itertools.count(start_idx):
             @retry_on_nas_error()
             def ensure_output_dir():
                 out_dir.mkdir(exist_ok=True)
@@ -136,8 +164,10 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             finally:
                 close_csv()
 
-    segmentation_writer = csv_writer("segmentation", CSV_SGMT_HEADER)
-    statement_writer = csv_writer("statement", CSV_STMT_HEADER)
+    seg_start = get_start_idx("segmentation")
+    stmt_start = get_start_idx("statement")
+    segmentation_writer = csv_writer("segmentation", CSV_SGMT_HEADER, seg_start)
+    statement_writer = csv_writer("statement", CSV_STMT_HEADER, stmt_start)
 
     # create dirs
     def safe_code_dirs():
@@ -174,9 +204,14 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
                 continue
             if None in (py_path, pyc_path):
                 continue
+            if str(py_path) in processed_paths:
+                if progress_bar:
+                    progress_bar.update()
+                continue
             yield (py_path, pyc_path)
 
     num_fails = 0
+    checkpoint_counter = 0
     with multiprocessing.Pool(maxtasksperchild=100) as pool:
         iterator = pool.imap_unordered(bytecode2csv_exception_wrapper, bytecode2csv_args())
         while True:
@@ -200,9 +235,26 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             for row, writerow in zip(statement_rows, statement_writer):
                 writerow(row)
 
+            # Track processed source file for resume
+            if segmentation_rows:
+                processed_paths.add(str(segmentation_rows[-1][-1]))
+            checkpoint_counter += 1
+            if checkpoint_counter >= 200:
+                try:
+                    checkpoint_file.write_text("\n".join(sorted(processed_paths)))
+                except OSError:
+                    pass
+                checkpoint_counter = 0
+
             if progress_bar:
                 progress_bar.update()
                 progress_bar.set_postfix({"num_fails": num_fails})
+
+    # Write final checkpoint
+    try:
+        checkpoint_file.write_text("\n".join(sorted(processed_paths)))
+    except OSError:
+        pass
 
     logger.info(f"NUMBER OF FAILS !!! {num_fails}")
 

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -56,32 +56,86 @@ def create_csv_dataset(code_dataset_path: pathlib.Path, csv_dataset_path: pathli
 
 def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger: logging.Logger = None, max_csv_rows: int = 30000, progress_bar: tqdm.tqdm = None):
     # validate output directory
-    if csv_output_path.exists():
-        if not csv_output_path.is_dir():
-            raise OSError("CSV output path is not a directory")
-    else:
-        csv_output_path.mkdir(parents=True)
+    @retry_on_nas_error()
+    def ensure_csv_output_dir():
+        if csv_output_path.exists():
+            if not csv_output_path.is_dir():
+                raise OSError("CSV output path is not a directory")
+        else:
+            csv_output_path.mkdir(parents=True)
+
+    try:
+        ensure_csv_output_dir()
+    except OSError as error:
+        if logger:
+            logger.warning(f"Unable to access CSV output directory {csv_output_path}: {error}; skipping split")
+        return
 
     ##### csv write wrappers to preserve csv row limit
 
     def csv_writer(file_prefix: str, csv_header: list) -> Callable:
         out_dir = csv_output_path.joinpath(file_prefix)
-        out_dir.mkdir(exist_ok=True)
 
         for csv_idx in itertools.count():
             @retry_on_nas_error()
-            def open_csv():
+            def ensure_output_dir():
+                out_dir.mkdir(exist_ok=True)
+
+            @retry_on_nas_error()
+            def open_csv(mode="w"):
                 new_path = out_dir.joinpath(f"{file_prefix}_{csv_idx}.csv")
-                new_path.touch()
-                return new_path.open(mode="w")
-            csv_file = open_csv()
+                if mode == "w":
+                    new_path.touch()
+                return new_path.open(mode=mode)
+
+            def discard_row(_row):
+                return None
+
+            try:
+                ensure_output_dir()
+                csv_file = open_csv()
+            except OSError as error:
+                if logger:
+                    logger.warning(f"Unable to open {file_prefix}_{csv_idx}.csv: {error}; dropping rows")
+                for _ in itertools.repeat(None, max_csv_rows):
+                    yield discard_row
+                continue
+
             if logger:
                 logger.info(f"Creating new csv {csv_file.name}...")
-            with csv_file:
-                writer = csv.writer(csv_file)
-                writer.writerow(csv_header)
-                for writer in itertools.repeat(writer, max_csv_rows):
-                    yield writer.writerow
+            writer = csv.writer(csv_file)
+
+            def close_csv():
+                try:
+                    csv_file.close()
+                except OSError as error:
+                    if logger:
+                        logger.warning(f"Unable to close {csv_file.name}: {error}")
+
+            def write_row(row):
+                nonlocal csv_file, writer
+                for attempt in range(3):
+                    try:
+                        return writer.writerow(row)
+                    except OSError as error:
+                        close_csv()
+                        if attempt == 2:
+                            if logger:
+                                logger.warning(f"Unable to write {file_prefix}_{csv_idx}.csv: {error}; dropping row")
+                            return None
+                        try:
+                            time.sleep(2**attempt)
+                            csv_file = open_csv(mode="a")
+                            writer = csv.writer(csv_file)
+                        except OSError:
+                            continue
+
+            try:
+                write_row(csv_header)
+                for _ in itertools.repeat(None, max_csv_rows):
+                    yield write_row
+            finally:
+                close_csv()
 
     segmentation_writer = csv_writer("segmentation", CSV_SGMT_HEADER)
     statement_writer = csv_writer("statement", CSV_STMT_HEADER)
@@ -124,7 +178,7 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             yield (py_path, pyc_path)
 
     num_fails = 0
-    with multiprocessing.Pool() as pool:
+    with multiprocessing.Pool(maxtasksperchild=1000) as pool:
         for result in pool.imap_unordered(bytecode2csv_exception_wrapper, bytecode2csv_args()):
             if isinstance(result, Exception):
                 num_fails += 1

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -70,19 +70,32 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             logger.warning(f"Unable to access CSV output directory {csv_output_path}: {error}; skipping split")
         return
 
-    # Resume: load checkpoint of already-processed source files
-    checkpoint_file = csv_output_path / ".checkpoint"
-    processed_paths: set[str] = set()
-    if checkpoint_file.exists():
+    # Resume: scan existing CSV files to find already-processed source paths
+    def load_processed_paths() -> set[str]:
+        """Read the file column from existing segmentation CSVs to determine which sources are done."""
+        processed = set()
+        seg_dir = csv_output_path.joinpath("segmentation")
+        if not seg_dir.exists():
+            return processed
         try:
-            for line in checkpoint_file.read_text().splitlines():
-                p = line.strip()
-                if p:
-                    processed_paths.add(p)
-            if logger and processed_paths:
-                logger.info(f"Resuming: {len(processed_paths)} source files already processed")
+            csv_files = sorted(seg_dir.glob("segmentation_*.csv"))
         except OSError:
-            pass
+            return processed
+        for csv_path in csv_files:
+            try:
+                with open(csv_path, "r") as f:
+                    reader = csv.reader(f)
+                    next(reader, None)  # skip header
+                    for row in reader:
+                        if row:
+                            processed.add(row[-1])
+            except (OSError, csv.Error, StopIteration):
+                continue
+        return processed
+
+    processed_paths = load_processed_paths()
+    if logger and processed_paths:
+        logger.info(f"Resuming: {len(processed_paths)} source files already in existing CSVs")
 
     def get_start_idx(prefix: str) -> int:
         """Return the next CSV file index after the highest existing one."""
@@ -211,7 +224,6 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             yield (py_path, pyc_path)
 
     num_fails = 0
-    checkpoint_counter = 0
     with multiprocessing.Pool(maxtasksperchild=100) as pool:
         iterator = pool.imap_unordered(bytecode2csv_exception_wrapper, bytecode2csv_args())
         while True:
@@ -235,27 +247,9 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             for row, writerow in zip(statement_rows, statement_writer):
                 writerow(row)
 
-            # Track processed source file for resume
-            if segmentation_rows:
-                processed_paths.add(str(segmentation_rows[-1][-1]))
-            checkpoint_counter += 1
-            if checkpoint_counter >= 200:
-                try:
-                    checkpoint_file.write_text("\n".join(sorted(processed_paths)))
-                except OSError:
-                    pass
-                checkpoint_counter = 0
-
             if progress_bar:
                 progress_bar.update()
                 progress_bar.set_postfix({"num_fails": num_fails})
-
-    # Write final checkpoint
-    try:
-        checkpoint_file.write_text("\n".join(sorted(processed_paths)))
-    except OSError:
-        pass
-
     logger.info(f"NUMBER OF FAILS !!! {num_fails}")
 
 

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -13,6 +13,7 @@ import logging
 import multiprocessing
 import pathlib
 import re
+import sys
 import time
 from typing import Callable, Tuple
 
@@ -74,6 +75,7 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
     def load_processed_paths() -> set[str]:
         """Read the file column from existing segmentation CSVs to determine which sources are done."""
         processed = set()
+        csv.field_size_limit(sys.maxsize)
         seg_dir = csv_output_path.joinpath("segmentation")
         if not seg_dir.exists():
             return processed
@@ -83,11 +85,11 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             return processed
         for csv_path in csv_files:
             try:
-                with open(csv_path, "r") as f:
+                with open(csv_path, "r", newline="") as f:
                     reader = csv.reader(f)
                     next(reader, None)  # skip header
                     for row in reader:
-                        if row:
+                        if len(row) == len(CSV_SGMT_HEADER):
                             processed.add(row[-1])
             except (OSError, csv.Error, StopIteration):
                 continue
@@ -96,6 +98,8 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
     processed_paths = load_processed_paths()
     if logger and processed_paths:
         logger.info(f"Resuming: {len(processed_paths)} source files already in existing CSVs")
+    if progress_bar:
+        progress_bar.update(len(processed_paths))
 
     def get_start_idx(prefix: str) -> int:
         """Return the next CSV file index after the highest existing one."""
@@ -218,8 +222,6 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             if None in (py_path, pyc_path):
                 continue
             if str(py_path) in processed_paths:
-                if progress_bar:
-                    progress_bar.update()
                 continue
             yield (py_path, pyc_path)
 

--- a/dev_scripts/dataset_generation/bytecode2csv.py
+++ b/dev_scripts/dataset_generation/bytecode2csv.py
@@ -8,9 +8,11 @@
 # ///
 
 import csv
+import faulthandler
 import itertools
 import logging
 import multiprocessing
+import os
 import pathlib
 import re
 import sys
@@ -29,6 +31,7 @@ bytecode_separator = " <SEP> "
 source_seperator = " <SEP> "
 CSV_SGMT_HEADER = ["source", "bytecode", "boundary", "file"]
 CSV_STMT_HEADER = ["source", "bytecode", "file"]
+_active_tasks = None
 
 
 def retry_on_nas_error(max_retries=3, base_delay=1):
@@ -44,6 +47,21 @@ def retry_on_nas_error(max_retries=3, base_delay=1):
                         raise
         return wrapper
     return decorator
+
+
+def initialize_worker(active_tasks):
+    global _active_tasks
+    _active_tasks = active_tasks
+    faulthandler.enable()
+
+
+def update_worker_stage(stage: str):
+    if _active_tasks is None:
+        return
+    pid = os.getpid()
+    task = _active_tasks.get(pid)
+    if task is not None:
+        _active_tasks[pid] = (*task[:3], stage)
 
 
 def create_csv_dataset(code_dataset_path: pathlib.Path, csv_dataset_path: pathlib.Path, data_requests: list[DataRequest], logger: logging.Logger = None):
@@ -226,40 +244,84 @@ def write_csvs(source_path: pathlib.Path, csv_output_path: pathlib.Path, logger:
             yield (py_path, pyc_path)
 
     num_fails = 0
-    with multiprocessing.Pool(maxtasksperchild=100) as pool:
-        iterator = pool.imap_unordered(bytecode2csv_exception_wrapper, bytecode2csv_args())
-        while True:
-            try:
-                result = iterator.next(timeout=300)
-            except StopIteration:
-                break
-            except multiprocessing.TimeoutError:
-                num_fails += 1
-                if logger:
-                    logger.warning(f"Task timed out after 300s (num_fails={num_fails})")
-                continue
-            if isinstance(result, Exception):
-                num_fails += 1
-                logger.debug(f"ERR: {result}\nTYPE ERR: {type(result)}\n")
-                continue
+    with multiprocessing.Manager() as manager:
+        active_tasks = manager.dict()
+        with multiprocessing.Pool(
+            maxtasksperchild=100,
+            initializer=initialize_worker,
+            initargs=(active_tasks,),
+        ) as pool:
+            iterator = pool.imap_unordered(bytecode2csv_exception_wrapper, bytecode2csv_args())
+            while True:
+                try:
+                    result = iterator.next(timeout=120)
+                except StopIteration:
+                    break
+                except multiprocessing.TimeoutError:
+                    tasks = dict(active_tasks)
+                    live_pids = {worker.pid for worker in multiprocessing.active_children() if worker.is_alive()}
+                    details = []
+                    now = time.time()
+                    for pid, (py_path, pyc_path, started_at, stage) in sorted(tasks.items()):
+                        status = "hung" if pid in live_pids else "crashed"
+                        details.append(
+                            f"PID {pid} ({status}, {now - started_at:.0f}s, {stage}): "
+                            f"{py_path} | {pyc_path}"
+                        )
+                    message = "No worker result for 120s; terminating wedged CSV pool."
+                    if details:
+                        message += "\nIn-flight tasks:\n" + "\n".join(details)
+                    if logger:
+                        logger.error(message)
+                    else:
+                        logging.error(message)
+                    num_fails += max(1, len(tasks))
+                    pool.terminate()
+                    break
 
-            (segmentation_rows, statement_rows) = result
-            for row, writerow in zip(segmentation_rows, segmentation_writer):
-                writerow(row)
-            for row, writerow in zip(statement_rows, statement_writer):
-                writerow(row)
+                live_pids = {worker.pid for worker in multiprocessing.active_children() if worker.is_alive()}
+                for pid, (py_path, pyc_path, started_at, stage) in list(active_tasks.items()):
+                    if pid in live_pids:
+                        continue
+                    active_tasks.pop(pid, None)
+                    num_fails += 1
+                    message = (
+                        f"Worker PID {pid} crashed after {time.time() - started_at:.0f}s during {stage}: "
+                        f"{py_path} | {pyc_path}"
+                    )
+                    if logger:
+                        logger.error(message)
+                    else:
+                        logging.error(message)
 
-            if progress_bar:
-                progress_bar.update()
-                progress_bar.set_postfix({"num_fails": num_fails})
+                if isinstance(result, Exception):
+                    num_fails += 1
+                    logger.debug(f"ERR: {result}\nTYPE ERR: {type(result)}\n")
+                    continue
+
+                (segmentation_rows, statement_rows) = result
+                for row, writerow in zip(segmentation_rows, segmentation_writer):
+                    writerow(row)
+                for row, writerow in zip(statement_rows, statement_writer):
+                    writerow(row)
+
+                if progress_bar:
+                    progress_bar.update()
+                    progress_bar.set_postfix({"num_fails": num_fails})
     logger.info(f"NUMBER OF FAILS !!! {num_fails}")
 
 
-def bytecode2csv_exception_wrapper(paths=Tuple[pathlib.Path, pathlib.Path]) -> Tuple[list, list] | Exception:
+def bytecode2csv_exception_wrapper(paths: Tuple[pathlib.Path, pathlib.Path]) -> Tuple[list, list] | Exception:
+    pid = os.getpid()
+    if _active_tasks is not None:
+        _active_tasks[pid] = (str(paths[0]), str(paths[1]), time.time(), "starting")
     try:
         return bytecode2csv(*paths)
     except Exception as error:
         return Exception(f"{type(error)}: {error} in file {paths}")
+    finally:
+        if _active_tasks is not None:
+            _active_tasks.pop(pid, None)
 
 
 @retry_on_nas_error()
@@ -268,13 +330,16 @@ def bytecode2csv(py_path: pathlib.Path, pyc_path: pathlib.Path) -> tuple[list, l
     segmentation_rows = []
     statement_rows = []
 
+    update_worker_stage("loading pyc")
     pyc = PYCFile(str(pyc_path.resolve()))
     if pyc.version == (3, 10):
         pyc.replace_duplicated_returns10(py_path.read_text().split("\n"))
     elif pyc.version >= (3, 12):
         pyc.replace_duplicated_returns12(py_path.read_text().split("\n"))
+    update_worker_stage("creating masker")
     global_masker = create_global_masker(pyc)
 
+    update_worker_stage("masking source")
     masked_source_text = mask_source(py_path, global_masker, pyc.version)
     masked_source_lines = masked_source_text.split("\n")
 
@@ -291,6 +356,7 @@ def bytecode2csv(py_path: pathlib.Path, pyc_path: pathlib.Path) -> tuple[list, l
 
     seen_lines = set()
 
+    update_worker_stage("building rows")
     # create rows for each bytecode
     for bc in pyc.iter_bytecodes():
         # we ignore comprehensions, hoisted later


### PR DESCRIPTION
This PR hardens the CSV dataset generation stage (`dev_scripts/dataset_generation/bytecode2csv.py`) against failure modes hit while generating on NAS-backed storage.

- NAS/OSError handling: file reads and CSV writes retry with exponential backoff, directory iteration no longer crashes the pool, and transient NAS errors during writes and worker processing are tolerated.
- Timeouts: `signal.alarm` occasionally interrupted C extension calls (marshal.loads, xdis) mid-operation, which could cause heap corruption and double free errors. This PR replaces them with a pool-level 300s timeout.
- Resume: the stage now writes a `.checkpoint` file of the source paths it has processed, skips them on restart, and continues from the highest existing CSV index instead of overwriting — so a crashed run no longer reprocesses everything from scratch.
- Stall reporting: workers report their current stage, and the main process distinguishes hung vs crashed workers, logs the in-flight tasks, and terminates wedged pools instead of hanging forever.