### PR TITLE
Training fixes: local artifacts and Transformers 5 compat

### DIFF
--- a/dev_scripts/segmentation/SegmentationConfiguration.py
+++ b/dev_scripts/segmentation/SegmentationConfiguration.py
@@ -36,6 +36,10 @@ class SegmentationConfiguration:
         return self.dataset_repo_name + "-tokenized"
 
     @property
+    def tokenized_dataset_dir(self):
+        return self.cache_dir / "datasets" / self.tokenized_dataset_repo_name
+
+    @property
     def mlm_repo_name(self):
         return self.base_repo_name + "-mlm"
 

--- a/dev_scripts/segmentation/tokenize_seg.py
+++ b/dev_scripts/segmentation/tokenize_seg.py
@@ -9,8 +9,10 @@
 
 import ast
 import functools
+import logging
 import os
 import pathlib
+import shutil
 import click
 
 from datasets import load_dataset
@@ -22,10 +24,12 @@ from transformers import PreTrainedTokenizerFast
 bytecode_separator = " <SEP> "
 
 
-def load_tokenizer(tokenizer_repo_name: str, cache_dir: pathlib.Path) -> PreTrainedTokenizerFast:
-    tokenizer_dir = cache_dir / "tokenizers" / tokenizer_repo_name
-
-    tokenizer_file = hf_hub_download(repo_id=tokenizer_repo_name, filename="tokenizer.json", token=True, cache_dir=str(tokenizer_dir))
+def load_tokenizer(tokenizer_json_path: pathlib.Path, tokenizer_repo_name: str, cache_dir: pathlib.Path) -> PreTrainedTokenizerFast:
+    if tokenizer_json_path.exists():
+        tokenizer_file = str(tokenizer_json_path)
+    else:
+        tokenizer_dir = cache_dir / "tokenizers" / tokenizer_repo_name
+        tokenizer_file = hf_hub_download(repo_id=tokenizer_repo_name, filename="tokenizer.json", token=True, cache_dir=str(tokenizer_dir))
     tokenizer = PreTrainedTokenizerFast(
         tokenizer_file=tokenizer_file,
         unk_token="[UNK]",
@@ -130,7 +134,7 @@ def tokenize_and_align_labels(tokenizer: PreTrainedTokenizerFast, max_length: in
 def tokenize_segmentation_dataset(config: SegmentationConfiguration, public: bool = False):
     raw_dataset = load_dataset(config.dataset_repo_name, token=True, cache_dir=str(config.dataset_dir))
 
-    tokenizer = load_tokenizer(config.tokenizer_repo_name, config.cache_dir)
+    tokenizer = load_tokenizer(config.tokenizer_json_path, config.tokenizer_repo_name, config.cache_dir)
     prepped_tokenize_and_align_labels = functools.partial(tokenize_and_align_labels, tokenizer, config.max_token_length)
 
     # tokenize input dataset
@@ -143,10 +147,20 @@ def tokenize_segmentation_dataset(config: SegmentationConfiguration, public: boo
         desc="Tokenizing datasets",
     )
 
-    tokenized_datasets.push_to_hub(
-        config.tokenized_dataset_repo_name,
-        private=not public,
-    )
+    if config.tokenized_dataset_dir.exists():
+        shutil.rmtree(config.tokenized_dataset_dir)
+    tokenized_datasets.save_to_disk(config.tokenized_dataset_dir)
+
+    try:
+        tokenized_datasets.push_to_hub(
+            config.tokenized_dataset_repo_name,
+            private=not public,
+        )
+    except Exception as error:
+        logging.warning(
+            f"Tokenized dataset saved locally but could not be uploaded to "
+            f"{config.tokenized_dataset_repo_name}: {error}"
+        )
 
 
 @click.command(help="Script to tokenize the segmentation dataset given a segmentation json.")

--- a/dev_scripts/segmentation/train_mlm.py
+++ b/dev_scripts/segmentation/train_mlm.py
@@ -22,15 +22,17 @@ from pylingual.segmentation.sliding_window import sliding_window
 bytecode_separator = " <SEP> "
 
 
-def load_tokenizer(tokenizer_repo_name: str, cache_dir: pathlib.Path) -> PreTrainedTokenizerFast:
-    tokenizer_dir = cache_dir / "tokenizers" / tokenizer_repo_name
-
-    tokenizer_file = hf_hub_download(
-        repo_id=tokenizer_repo_name,
-        filename="tokenizer.json",
-        token=True,
-        cache_dir=str(tokenizer_dir),
-    )
+def load_tokenizer(tokenizer_json_path: pathlib.Path, tokenizer_repo_name: str, cache_dir: pathlib.Path) -> PreTrainedTokenizerFast:
+    if tokenizer_json_path.exists():
+        tokenizer_file = str(tokenizer_json_path)
+    else:
+        tokenizer_dir = cache_dir / "tokenizers" / tokenizer_repo_name
+        tokenizer_file = hf_hub_download(
+            repo_id=tokenizer_repo_name,
+            filename="tokenizer.json",
+            token=True,
+            cache_dir=str(tokenizer_dir),
+        )
     tokenizer = PreTrainedTokenizerFast(
         tokenizer_file=tokenizer_file,
         unk_token="[UNK]",
@@ -150,7 +152,7 @@ def train_mlm(config: SegmentationConfiguration, public: bool = False):
         save_steps=1000,
         save_total_limit=5,
         prediction_loss_only=True,
-        push_to_hub=True,
+        push_to_hub=False,
         hub_model_id=config.mlm_repo_name,
         hub_private_repo=not public,
         ddp_backend="nccl",
@@ -158,7 +160,7 @@ def train_mlm(config: SegmentationConfiguration, public: bool = False):
         remove_unused_columns=False,
     )
 
-    tokenizer = load_tokenizer(config.tokenizer_repo_name, config.cache_dir)
+    tokenizer = load_tokenizer(config.tokenizer_json_path, config.tokenizer_repo_name, config.cache_dir)
 
     # Set DataCollator for MLM task, set the probability of masking.
     data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=True, mlm_probability=0.15)
@@ -181,15 +183,18 @@ def train_mlm(config: SegmentationConfiguration, public: bool = False):
     # Training
     trainer.train()
 
-    if int(os.environ["LOCAL_RANK"]) == 0:
+    if int(os.environ.get("LOCAL_RANK", "0")) == 0:
         # Save the model
         trainer.save_model(config.mlm_dir)
 
-        trainer.push_to_hub(
-            finetuned_from=config.pretrained_mlm_repo_name,
-            dataset=config.dataset_repo_name,
-            commit_message=f"Trained on {config.dataset_repo_name} using {config.tokenizer_repo_name}",
-        )
+        try:
+            trainer.push_to_hub(
+                finetuned_from=config.pretrained_mlm_repo_name,
+                dataset=config.dataset_repo_name,
+                commit_message=f"Trained on {config.dataset_repo_name} using {config.tokenizer_repo_name}",
+            )
+        except Exception as error:
+            logging.warning(f"MLM saved locally but could not be uploaded to {config.mlm_repo_name}: {error}")
 
 
 @click.command(help="Training script for the masked language model pretraining for the segmentation model given a segmentation json.")

--- a/dev_scripts/segmentation/train_seg.py
+++ b/dev_scripts/segmentation/train_seg.py
@@ -5,7 +5,7 @@ import click
 
 import evaluate
 import numpy as np
-from datasets import ReadInstruction, load_dataset
+from datasets import ReadInstruction, load_dataset, load_from_disk
 from huggingface_hub import hf_hub_download, repo_exists
 from SegmentationConfiguration import SegmentationConfiguration, parse_segmentation_config_json
 from transformers import AutoModelForTokenClassification, DataCollatorForTokenClassification, PreTrainedTokenizerFast, Trainer, TrainingArguments
@@ -35,15 +35,17 @@ def compute_metrics(eval_preds):
     }
 
 
-def load_tokenizer(tokenizer_repo_name: str, cache_dir: pathlib.Path) -> PreTrainedTokenizerFast:
-    tokenizer_dir = cache_dir / "tokenizers" / tokenizer_repo_name
-
-    tokenizer_file = hf_hub_download(
-        repo_id=tokenizer_repo_name,
-        filename="tokenizer.json",
-        token=True,
-        cache_dir=str(tokenizer_dir),
-    )
+def load_tokenizer(tokenizer_json_path: pathlib.Path, tokenizer_repo_name: str, cache_dir: pathlib.Path) -> PreTrainedTokenizerFast:
+    if tokenizer_json_path.exists():
+        tokenizer_file = str(tokenizer_json_path)
+    else:
+        tokenizer_dir = cache_dir / "tokenizers" / tokenizer_repo_name
+        tokenizer_file = hf_hub_download(
+            repo_id=tokenizer_repo_name,
+            filename="tokenizer.json",
+            token=True,
+            cache_dir=str(tokenizer_dir),
+        )
     tokenizer = PreTrainedTokenizerFast(
         tokenizer_file=tokenizer_file,
         unk_token="[UNK]",
@@ -56,7 +58,14 @@ def load_tokenizer(tokenizer_repo_name: str, cache_dir: pathlib.Path) -> PreTrai
     return tokenizer
 
 
-def load_tokenized_train_and_valid_dataset(dataset_repo_name: str, cache_dir: pathlib.Path, dataset_percentage: int = 100):
+def load_tokenized_train_and_valid_dataset(dataset_repo_name: str, cache_dir: pathlib.Path, dataset_percentage: int = 100, dataset_dir: pathlib.Path | None = None):
+    if dataset_dir is not None and dataset_dir.exists():
+        tokenized_dataset = load_from_disk(dataset_dir)
+        tokenized_train_dataset = tokenized_dataset["train"]
+        if dataset_percentage < 100:
+            tokenized_train_dataset = tokenized_train_dataset.select(range(len(tokenized_train_dataset) * dataset_percentage // 100))
+        return tokenized_train_dataset, tokenized_dataset["valid"]
+
     dataset_dir = cache_dir / "datasets" / dataset_repo_name
     # Load the tokenized dataset
     tokenized_train_dataset = load_dataset(
@@ -83,7 +92,6 @@ def train_segmentation_model(config: SegmentationConfiguration, public: bool = F
     # training arguments.
     training_args = TrainingArguments(
         output_dir=str(config.segmenter_dir),
-        overwrite_output_dir=True,
         eval_strategy="epoch",
         logging_strategy="epoch",
         save_strategy="epoch",
@@ -93,7 +101,7 @@ def train_segmentation_model(config: SegmentationConfiguration, public: bool = F
         save_steps=1000,
         weight_decay=0.01,
         fp16=True,
-        push_to_hub=True,
+        push_to_hub=False,
         hub_model_id=config.segmenter_repo_name,
         hub_private_repo=not public,
         ddp_backend="nccl",
@@ -102,21 +110,27 @@ def train_segmentation_model(config: SegmentationConfiguration, public: bool = F
     )
 
     # load a basic pretrained BERT model
+    mlm_source = str(config.mlm_dir) if config.mlm_dir.exists() else config.mlm_repo_name
     model = AutoModelForTokenClassification.from_pretrained(
-        pretrained_model_name_or_path=config.mlm_repo_name,
+        pretrained_model_name_or_path=mlm_source,
         id2label=id2label,
         label2id=label2id,
         token=True,
     )
 
     # Set DataCollator for DataCollatorForTokenClassification
-    tokenizer = load_tokenizer(config.tokenizer_repo_name, config.cache_dir)
+    tokenizer = load_tokenizer(config.tokenizer_json_path, config.tokenizer_repo_name, config.cache_dir)
     data_collator = DataCollatorForTokenClassification(tokenizer=tokenizer, max_length=config.max_token_length)
 
     (
         tokenized_train_dataset,
         tokenized_validation_dataset,
-    ) = load_tokenized_train_and_valid_dataset(config.tokenized_dataset_repo_name, config.cache_dir, config.dataset_percentage)
+    ) = load_tokenized_train_and_valid_dataset(
+        config.tokenized_dataset_repo_name,
+        config.cache_dir,
+        config.dataset_percentage,
+        config.tokenized_dataset_dir,
+    )
 
     # Hugging face trainer: a Trainer class to fine-tune pretrained models
     trainer = Trainer(
@@ -126,21 +140,26 @@ def train_segmentation_model(config: SegmentationConfiguration, public: bool = F
         train_dataset=tokenized_train_dataset,
         eval_dataset=tokenized_validation_dataset,
         compute_metrics=compute_metrics,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
     )
 
     # Training
     trainer.train()
 
-    if int(os.environ["LOCAL_RANK"]) == 0:
+    if int(os.environ.get("LOCAL_RANK", "0")) == 0:
         # Save the model
         trainer.save_model(str(config.segmenter_dir))
 
-        trainer.push_to_hub(
-            finetuned_from=config.mlm_repo_name,
-            dataset=config.tokenized_dataset_repo_name,
-            commit_message=f"Trained on {config.tokenized_dataset_repo_name} using {config.mlm_repo_name}",
-        )
+        try:
+            trainer.push_to_hub(
+                finetuned_from=config.mlm_repo_name,
+                dataset=config.tokenized_dataset_repo_name,
+                commit_message=f"Trained on {config.tokenized_dataset_repo_name} using {config.mlm_repo_name}",
+            )
+        except Exception as error:
+            logging.warning(
+                f"Segmenter saved locally but could not be uploaded to {config.segmenter_repo_name}: {error}"
+            )
 
 
 @click.command(help="Training script for the segmentation model given a segmentation json.")

--- a/dev_scripts/segmentation/train_tokenizer.py
+++ b/dev_scripts/segmentation/train_tokenizer.py
@@ -48,14 +48,17 @@ def save_and_upload_tokenizer(
     tokenizer_json_path.parent.mkdir(parents=True, exist_ok=True)
     tokenizer.save(str(tokenizer_json_path.resolve()))
 
-    api = HfApi()
-    create_repo(tokenizer_repo_name, exist_ok=True, private=not public)
-    api.upload_file(
-        path_in_repo="tokenizer.json",
-        path_or_fileobj=str(tokenizer_json_path.resolve()),
-        repo_id=tokenizer_repo_name,
-        commit_message=f"Trained tokenizer using {dataset_name}",
-    )
+    try:
+        api = HfApi()
+        create_repo(tokenizer_repo_name, exist_ok=True, private=not public)
+        api.upload_file(
+            path_in_repo="tokenizer.json",
+            path_or_fileobj=str(tokenizer_json_path.resolve()),
+            repo_id=tokenizer_repo_name,
+            commit_message=f"Trained tokenizer using {dataset_name}",
+        )
+    except Exception as error:
+        logging.warning(f"Tokenizer saved locally but could not be uploaded to {tokenizer_repo_name}: {error}")
 
 
 def train_tokenizer(config: SegmentationConfiguration, public: bool = False):

--- a/dev_scripts/statement/train_seq2seq.py
+++ b/dev_scripts/statement/train_seq2seq.py
@@ -63,14 +63,14 @@ def train_statement_model(config: StatementConfiguration, public: bool = False):
         args=train_args,
         data_collator=data_collator,
         train_dataset=tokenized_train_dataset,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
     )
 
     start = time.time()
     trainer.train()
     duration = str(timedelta(seconds=time.time() - start))
 
-    if int(os.environ["LOCAL_RANK"]) == 0:
+    if int(os.environ.get("LOCAL_RANK", "0")) == 0:
         # upload the latest version of the model to the Model Hub on Huggingface
         trainer.save_model(str(config.statement_model_dir))
         # this command returns the URL of the commit it just did

--- a/dev_scripts/train_models.py
+++ b/dev_scripts/train_models.py
@@ -25,7 +25,7 @@ def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.L
 
     # train tokenizer
     logger.info("training tokenizer...")
-    subprocess.run(["uv", "run", segmentation_root / "train_tokenizer.py", *_public_flag(public), segmentation_config_path])
+    subprocess.run(["uv", "run", segmentation_root / "train_tokenizer.py", *_public_flag(public), segmentation_config_path], check=True)
 
     # train mlm (single gpu to avoid conflicts with local tokenized data)
     logger.info("training masked language model...")
@@ -43,11 +43,12 @@ def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.L
             segmentation_config_path,
         ],
         env=dict(os.environ, NCCL_P2P_DISABLE="1"),
+        check=True,
     )
 
     # tokenize dataset
     logger.info("tokenizing segmentation dataset...")
-    subprocess.run(["uv", "run", segmentation_root / "tokenize_seg.py", *_public_flag(public), segmentation_config_path])
+    subprocess.run(["uv", "run", segmentation_root / "tokenize_seg.py", *_public_flag(public), segmentation_config_path], check=True)
 
     # train segmentation model (4 gpus)
     logger.info("training segmentation model...")
@@ -65,6 +66,7 @@ def train_segmentation(segmentation_config_path: pathlib.Path, logger: logging.L
             segmentation_config_path,
         ],
         env=dict(os.environ, NCCL_P2P_DISABLE="1"),
+        check=True,
     )
 
 
@@ -72,11 +74,11 @@ def train_statement(statement_config_path: pathlib.Path, logger: logging.Logger,
     statement_root = pathlib.Path(__file__).parent / "statement"
 
     # manual tokenizer
-    subprocess.run(["uv", "run", statement_root / "train_tokenizer_auto.py", *_public_flag(public), statement_config_path])
+    subprocess.run(["uv", "run", statement_root / "train_tokenizer_auto.py", *_public_flag(public), statement_config_path], check=True)
 
     # tokenize statement dataset with salesforce tokenizer
     logger.info("tokenizing statement dataset...")
-    subprocess.run(["uv", "run", statement_root / "tokenize_seq2seq.py", *_public_flag(public), statement_config_path])
+    subprocess.run(["uv", "run", statement_root / "tokenize_seq2seq.py", *_public_flag(public), statement_config_path], check=True)
 
     # train statement model (4 gpus)
     logger.info("training statement model...")
@@ -94,6 +96,7 @@ def train_statement(statement_config_path: pathlib.Path, logger: logging.Logger,
             statement_config_path,
         ],
         env=dict(os.environ, NCCL_P2P_DISABLE="1"),
+        check=True,
     )
 
 


### PR DESCRIPTION
The model training script is rather brittle and breaks when HF hub is unavailable or we are out of storage space. 

Segmentation training now prioritizes local artifacts. It still tries to upload to hub, but rather than wasting time redownloading after upload succeeds, it just proceeds even if hub upload fails and the hub upload can be fixed and re-attempted later (better for unattended training runs, less chance of failing and not actually doing the training). 

Tokenized datasets are also saved to disk locally instead of only being uploaded to the HF Hub, so local failures are more recoverable. 

The statement trainer is updated for Transformers 5: `tokenizer=` is passed as `processing_class=`, and `LOCAL_RANK` is read with a default so the rank-0 guard doesn't crash when the env var is unset.

`check=True` also added to subprocess `uv` invocations, so that if a particular training stage fails, it will stop the pipeline instead of wasting compute on trying to do later steps and being silently messed up.